### PR TITLE
Added Vector4 identity constructor

### DIFF
--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -44,6 +44,10 @@ class Vector4 {
   //// Zero vector.
   Vector4.zero() : storage = new Float32List(4) ;
 
+  /// Constructs the identity vector.
+  Vector4.identity() : storage = new Float32List(4) {
+    storage[3] = 1.0;
+  }
   /// Copy of [other].
   Vector4.copy(Vector4 other) :
     storage = new Float32List(4) {


### PR DESCRIPTION
I am migrating the Dart three.dart library to use vector_math. The Vector4.identity constructor would correspond to their Vector4 default constructor so that I don't have to use new Vector4(0.0, 0.0, 0.0, 1.0)
