### PR TITLE
Change Aabb2/3 contains() to be not reflexive

### DIFF
--- a/lib/src/vector_math/aabb2.dart
+++ b/lib/src/vector_math/aabb2.dart
@@ -116,10 +116,10 @@ class Aabb2 {
 
   /// Return if [this] contains [other].
   bool contains(Aabb2 other) {
-    return min.x <= other.min.x &&
-           min.y <= other.min.y &&
-           max.y >= other.max.y &&
-           max.x >= other.max.x;
+    return min.x < other.min.x &&
+           min.y < other.min.y &&
+           max.y > other.max.y &&
+           max.x > other.max.x;
   }
 
   /// Return if [this] intersects with [other].

--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -128,12 +128,12 @@ class Aabb3 {
 
   /// Return if [this] contains [other].
   bool contains(Aabb3 other) {
-    return min.x <= other.min.x &&
-           min.y <= other.min.y &&
-           min.z <= other.min.z &&
-           max.x >= other.max.x &&
-           max.y >= other.max.y &&
-           max.z >= other.max.z;
+    return min.x < other.min.x &&
+           min.y < other.min.y &&
+           min.z < other.min.z &&
+           max.x > other.max.x &&
+           max.y > other.max.y &&
+           max.z > other.max.z;
   }
 
   /// Return if [this] intersects with [other].

--- a/test/test_aabb.dart
+++ b/test/test_aabb.dart
@@ -18,7 +18,7 @@ class AabbTest extends BaseTest {
     final Aabb2 grandParent = new Aabb2.minmax(_v(0.0,0.0), _v(10.0,10.0));
 
     expect(parent.contains(child), isTrue);
-    expect(parent.contains(parent), isTrue);
+    expect(parent.contains(parent), isFalse);
     expect(parent.contains(cutting), isFalse);
     expect(parent.contains(outside), isFalse);
     expect(parent.contains(grandParent), isFalse);
@@ -66,9 +66,6 @@ class AabbTest extends BaseTest {
     expect(a.min.y, equals(1.0));
     expect(a.max.x, equals(6.0));
     expect(a.max.y, equals(4.0));
-
-    expect(a.contains(a), isTrue);
-    expect(a.contains(b), isTrue);
   }
 
   void testAabb2Rotate() {
@@ -125,7 +122,7 @@ class AabbTest extends BaseTest {
     final Aabb3 grandParent = new Aabb3.minmax(_v3(0.0,0.0,0.0), _v3(10.0,10.0,10.0));
 
     expect(parent.contains(child), isTrue);
-    expect(parent.contains(parent), isTrue);
+    expect(parent.contains(parent), isFalse);
     expect(parent.contains(cutting), isFalse);
     expect(parent.contains(outside), isFalse);
     expect(parent.contains(grandParent), isFalse);
@@ -174,9 +171,6 @@ class AabbTest extends BaseTest {
     expect(a.max.x, equals(6.0));
     expect(a.max.y, equals(4.0));
     expect(a.max.z, equals(10.0));
-
-    expect(a.contains(a), isTrue);
-    expect(a.contains(b), isTrue);
   }
 
   void run() {


### PR DESCRIPTION
I made a mistake when porting the Aabb2#contains(other) method from box2d. The collision of box2d handling gets instable when contains() returns true for an other box of the exactly same size.
