### PR TITLE
adds postmutliply methods to vector classes

### DIFF
--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -175,7 +175,12 @@ class Vector2 {
     return sum;
   }
   
-  ///Post-multiply by a transformation, [arg]
+  /**
+   * Transforms [this] into the product of [this] as a row vector,
+   * postmultiplied by matrix, [arg].
+   * If [arg] is a rotation matrix, this is a computational shortcut for applying,
+   * the inverse of the transformation.
+   */
   Vector2 postmultiply(Matrix2 arg) {
     double v0 = storage[0];
     double v1 = storage[1];

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -187,7 +187,12 @@ class Vector3 {
     return sum;
   }
   
-  ///Post-multiply by a transformation, [arg]
+  /**
+   * Transforms [this] into the product of [this] as a row vector,
+   * postmultiplied by matrix, [arg].
+   * If [arg] is a rotation matrix, this is a computational shortcut for applying,
+   * the inverse of the transformation.
+   */
   Vector3 postmultiply(Matrix3 arg) {
     double v0 = storage[0];
     double v1 = storage[1];

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -212,20 +212,6 @@ class Vector4 {
     sum += storage[3] * other.storage[3];
     return sum;
   }
-  
-  ///Post-multiply by a transformation, [arg]
-  Vector4 postmultiply(Matrix4 arg) {
-    double v0 = storage[0];
-    double v1 = storage[1];
-    double v2 = storage[2];
-    double v3 = storage[3];
-    storage[0] = v0*arg.storage[0]+v1*arg.storage[1]+v2*arg.storage[2]+v3*arg.storage[3];
-    storage[1] = v0*arg.storage[4]+v1*arg.storage[5]+v2*arg.storage[6]+v3*arg.storage[7];
-    storage[2] = v0*arg.storage[8]+v1*arg.storage[9]+v2*arg.storage[10]+v3*arg.storage[11];
-    storage[3] = v0*arg.storage[12]+v1*arg.storage[13]+v2*arg.storage[14]+v3*arg.storage[15];
-    
-    return this;
-  }
 
   /// Relative error between [this] and [correct]
   double relativeError(Vector4 correct) {

--- a/test/test_vector.dart
+++ b/test/test_vector.dart
@@ -64,10 +64,17 @@ class VectorTest extends BaseTest {
   void testVec2Postmultiplication(){
     Matrix2 inputMatrix = new Matrix2.rotation(.2);
     Vector2 inputVector = new Vector2(1.0,0.0);
+    Matrix2 inputInv = new Matrix2.copy(inputMatrix);
+    inputInv.invert();
+    print("input $inputMatrix");
+    print("input $inputInv");
     Vector2 resultOld = inputMatrix.transposed() * inputVector;
+    Vector2 resultOldvInv = inputInv * inputVector;
     Vector2 resultNew = inputVector.postmultiply(inputMatrix);
     expect(resultNew.x, equals(resultOld.x));
     expect(resultNew.y, equals(resultOld.y));
+    //matrix inversion can introduce a small error
+    assert((resultNew-resultOldvInv).length < .00001);
   }
 
   void testVec2CrossProduct() {
@@ -125,11 +132,18 @@ class VectorTest extends BaseTest {
   void testVec3Postmultiplication(){
     Matrix3 inputMatrix = (new Matrix3.rotationX(.4))*(new Matrix3.rotationZ(.5));
     Vector3 inputVector = new Vector3(1.0,2.0,3.0);
+    Matrix3 inputInv = new Matrix3.copy(inputMatrix);
+    inputInv.invert();
     Vector3 resultOld = inputMatrix.transposed() * inputVector;
+    Vector3 resultOldvInv = inputInv * inputVector;
     Vector3 resultNew = inputVector.postmultiply(inputMatrix);
+    
     expect(resultNew.x, equals(resultOld.x));
     expect(resultNew.y, equals(resultOld.y));
     expect(resultNew.z, equals(resultOld.z));
+    expect(resultNew.x, equals(resultOldvInv.x));
+    expect(resultNew.y, equals(resultOldvInv.y));
+    expect(resultNew.z, equals(resultOldvInv.z));
   }
   
   void testVec3CrossProduct() {


### PR DESCRIPTION
Post-multiplication applies the inverse of a rotation without having to
create any new vector objects or modifying the transformation matrix.
So, v.postmultiply(m) is equal to m.transposed() \* v.

This is useful for converting a vector in the global frame to it's
equivalent in a frame described by a certain matrix.

I apologize in advance if I have breached any protocol here, this is my first pull-request ever...
