### PR TITLE
prep fer v 1.4.2+1

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,3 +7,4 @@ Contributors:
 Brandon Jones <bajones@google.com>
 Don Olmstead <don.j.olmstead@gmail.com>
 Adam Singer <financeCoding@gmail.com>
+Kevin Moore <github@j832.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: vector_math
-version: 1.4.2
+version: 1.4.2+1
 author: John McCutchan <john@johnmccutchan.com>
 description: A Vector Math library for 2D and 3D applications.
 homepage: https://github.com/johnmccutchan/vector_math
-dependencies:
-  benchmark_harness: any
+environment:
+  sdk: '>=1.0.0'
 dev_dependencies:
+  benchmark_harness: any
   browser: any
   hop: any
   unittest: any


### PR DESCRIPTION
added myself to authors
moved benchmark_harness to dev_depenedncies (not needed by users of lib)
