### PR TITLE
Added setLength() method to Vector2, Vector3 and Vector4

### DIFF
--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -20,7 +20,6 @@
 */
 
 part of vector_math;
-
 /// 2D column vector.
 class Vector2 implements Vector {
   final Float32List storage = new Float32List(2);
@@ -141,7 +140,31 @@ class Vector2 implements Vector {
     return sum;
   }
 
-  /// Normalize [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector2 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector2 normalize() {
     double l = length;
     // TODO(johnmccutchan): Use an epsilon.

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -39,7 +39,7 @@ class Vector3 implements Vector{
     result.z = Math.max(a.z, b.z);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear 
+  // Interpolate between [min] and [max] with the amount of [a] using a linear
   // interpolation and set the values to [result].
   static void mix(Vector3 min, Vector3 max, double a, Vector3 result) {
     result.x = min.x + a * (max.x - min.x);
@@ -65,7 +65,7 @@ class Vector3 implements Vector{
 
   /// Splat [value] into all lanes of the vector.
   Vector3.all(double value) : this(value, value, value);
-  
+
   /// Copy of [other].
   Vector3.copy(Vector3 other) : storage = new Float32List(3) {
     setFrom(other);
@@ -159,7 +159,33 @@ class Vector3 implements Vector{
     return sum;
   }
 
-  /// Normalizes [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector3 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+      storage[2] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+      storage[2] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector3 normalize() {
     double l = length;
     if (l == 0.0) {

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -41,7 +41,7 @@ class Vector4 implements Vector {
     result.w = Math.max(a.w, b.w);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear 
+  // Interpolate between [min] and [max] with the amount of [a] using a linear
   // interpolation and set the values to [result].
   static void mix(Vector4 min, Vector4 max, double a, Vector4 result) {
     result.x = min.x + a * (max.x - min.x);
@@ -174,7 +174,35 @@ class Vector4 implements Vector {
     return sum;
   }
 
-  /// Normalizes [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector4 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+      storage[2] = 0.0;
+      storage[3] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+      storage[2] *= l;
+      storage[3] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector4 normalize() {
     double l = length;
     // TODO(johnmccutchan): Use an epsilon.

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -37,7 +37,7 @@ class Vector2 {
     result.y = Math.max(a.y, b.y);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear 
+  // Interpolate between [min] and [max] with the amount of [a] using a linear
   // interpolation and set the values to [result].
   static void mix(Vector2 min, Vector2 max, double a, Vector2 result) {
     result.x = min.x + a * (max.x - min.x);
@@ -141,7 +141,31 @@ class Vector2 {
     return sum;
   }
 
-  /// Normalize [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector2 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector2 normalize() {
     double l = length;
     // TODO(johnmccutchan): Use an epsilon.
@@ -194,7 +218,7 @@ class Vector2 {
     sum += storage[1] * other.storage[1];
     return sum;
   }
-  
+
   /**
    * Transforms [this] into the product of [this] as a row vector,
    * postmultiplied by matrix, [arg].
@@ -206,7 +230,7 @@ class Vector2 {
     double v1 = storage[1];
     storage[0] = v0*arg.storage[0]+v1*arg.storage[1];
     storage[1] = v0*arg.storage[2]+v1*arg.storage[3];
-    
+
     return this;
   }
 

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -39,7 +39,7 @@ class Vector3 {
     result.z = Math.max(a.z, b.z);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear 
+  // Interpolate between [min] and [max] with the amount of [a] using a linear
   // interpolation and set the values to [result].
   static void mix(Vector3 min, Vector3 max, double a, Vector3 result) {
     result.x = min.x + a * (max.x - min.x);
@@ -65,7 +65,7 @@ class Vector3 {
 
   /// Splat [value] into all lanes of the vector.
   Vector3.all(double value) : this(value, value, value);
-  
+
   /// Copy of [other].
   Vector3.copy(Vector3 other) : storage = new Float64List(3) {
     setFrom(other);
@@ -159,7 +159,33 @@ class Vector3 {
     return sum;
   }
 
-  /// Normalizes [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector3 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+      storage[2] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+      storage[2] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector3 normalize() {
     double l = length;
     if (l == 0.0) {

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -41,7 +41,7 @@ class Vector4 {
     result.w = Math.max(a.w, b.w);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear 
+  // Interpolate between [min] and [max] with the amount of [a] using a linear
   // interpolation and set the values to [result].
   static void mix(Vector4 min, Vector4 max, double a, Vector4 result) {
     result.x = min.x + a * (max.x - min.x);
@@ -174,7 +174,35 @@ class Vector4 {
     return sum;
   }
 
-  /// Normalizes [this].
+  /**
+   * Set length of [this].
+   * If [newLength] is less than or equal to 0.0, has same effect as calling [setZero()].
+   * if [length] is 0.0, has no effect.
+   */
+  Vector4 setLength(double newLength) {
+    double l = length;
+    if (l == 0.0) {
+      return this;
+    }
+    if (newLength <= 0.0) {
+      storage[0] = 0.0;
+      storage[1] = 0.0;
+      storage[2] = 0.0;
+      storage[3] = 0.0;
+    } else {
+      l = newLength / l;
+      storage[0] *= l;
+      storage[1] *= l;
+      storage[2] *= l;
+      storage[3] *= l;
+    }
+    return this;
+  }
+
+  /**
+   * Normalizes [this].
+   * if [length] is 0.0, has no effect.
+   */
   Vector4 normalize() {
     double l = length;
     // TODO(johnmccutchan): Use an epsilon.


### PR DESCRIPTION
Added a setLength() method to Vector2, Vector3 and Vector4, both 32 and 64 bit versions.

This can be viewed as a generalized version of normalize(), an I've tried to make the implementations very similar. the behavior when the existing length==0.0 is the same.