### PR TITLE
Cleanup AABB

### DIFF
--- a/lib/src/vector_math/aabb2.dart
+++ b/lib/src/vector_math/aabb2.dart
@@ -152,18 +152,38 @@ class Aabb2 {
   }
 
   /// Return if [this] contains [other].
-  bool containsAabb2(Aabb2 other) => _min.x < other._min.x && _min.y <
-      other._min.y && _max.y > other._max.y && _max.x > other._max.x;
+  bool containsAabb2(Aabb2 other) {
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x < otherMin.x && _min.y < otherMin.y && _max.y > otherMax.y &&
+        _max.x > otherMax.x;
+  }
 
   /// Return if [this] contains [other].
-  bool containsVector2(Vector2 other) => _min.x < other.x && _min.y < other.y &&
-      _max.x > other.x && _max.y > other.y;
+  bool containsVector2(Vector2 other) {
+    final otherX = other[0];
+    final otherY = other[1];
+
+    return _min.x < otherX && _min.y < otherY && _max.x > otherX && _max.y >
+        otherY;
+  }
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithAabb2(Aabb2 other) => _min.x <= other._max.x && _min.y <=
-      other._max.y && _max.x >= other._min.x && _max.y >= other._min.y;
+  bool intersectsWithAabb2(Aabb2 other) {
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x <= otherMax.x && _min.y <= otherMax.y && _max.x >= otherMin.x
+        && _max.y >= otherMin.y;
+  }
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithVector2(Vector2 other) => _min.x <= other.x && _min.y <=
-      other.y && _max.x >= other.x && _max.y >= other.y;
+  bool intersectsWithVector2(Vector2 other) {
+    final otherX = other[0];
+    final otherY = other[1];
+
+    return _min.x <= otherX && _min.y <= otherY && _max.x >= otherX && _max.y >=
+        otherY;
+  }
 }

--- a/lib/src/vector_math/aabb2.dart
+++ b/lib/src/vector_math/aabb2.dart
@@ -21,102 +21,128 @@
 
 part of vector_math;
 
+/// Defines a 2-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb2 {
   final Vector2 _min;
   final Vector2 _max;
 
+  /// The minimum point defining the AABB.
   Vector2 get min => _min;
+  /// The maximum point defining the AABB.
   Vector2 get max => _max;
 
-  Vector2 get center {
-    Vector2 c = new Vector2.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector2 get center => _min.clone()
+      ..add(_max)
+      ..scale(0.5);
 
-  Aabb2() :
-    _min = new Vector2.zero(),
-    _max = new Vector2.zero() {}
+  /// Create a new AABB with [min] and [max] set to the origin.
+  Aabb2()
+      : _min = new Vector2.zero(),
+        _max = new Vector2.zero();
 
-  Aabb2.copy(Aabb2 other) :
-    _min = new Vector2.copy(other._min),
-    _max = new Vector2.copy(other._max) {}
+  /// Create a new AABB as a copy of [other].
+  Aabb2.copy(Aabb2 other)
+      : _min = new Vector2.copy(other._min),
+        _max = new Vector2.copy(other._max);
 
+  /// DEPREACTED: Use [minMax] instead.
   @deprecated
-  Aabb2.minmax(Vector2 min_, Vector2 max_) :
-    _min = new Vector2.copy(min_),
-    _max = new Vector2.copy(max_) {}
+  Aabb2.minmax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  Aabb2.minMax(Vector2 min_, Vector2 max_) :
-    _min = new Vector2.copy(min_),
-    _max = new Vector2.copy(max_) {}
+  /// Create a new AABB with a [min] and [max].
+  Aabb2.minMax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  void copyMinMax(Vector2 min_, Vector2 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
+  /// Create a new AABB with a [center] and [halfExtents].
+  Aabb2.centerAndHalfExtents(Vector2 center, Vector2 halfExtents)
+      : _min = new Vector2.copy(center)..sub(halfExtents),
+        _max = new Vector2.copy(center)..add(halfExtents);
+
+  //TODO (fox32): A fromBuffer constructor is missing here?
+
+  /// DEPREACTED: Removed copy min and max yourself
+  @deprecated
+  void copyMinMax(Vector2 min, Vector2 max) {
+    max.setFrom(_max);
+    min.setFrom(_min);
   }
 
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+        ..setFrom(_min)
+        ..add(_max)
+        ..scale(0.5);
+    halfExtents
+        ..setFrom(_max)
+        ..sub(_min)
+        ..scale(0.5);
   }
 
-  void copyFrom(Aabb2 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb2 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb2 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [this] into [other].
+  void copyInto(Aabb2 other) {
+    other._min.setFrom(_min);
+    other._max.setFrom(_max);
   }
 
-  Aabb2 transform(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Transform [this] by the transform [t].
+  void transform(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform2(center);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t
+        ..transform2(center)
+        ..absoluteRotate2(halfExtents);
+    _min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    _max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb2 rotate(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  void rotate(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t.absoluteRotate2(halfExtents);
+    _min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    _max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb2 transformed(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb2 transformed(Matrix3 t, Aabb2 out) => out
+      ..copyFrom(this)
+      ..transform(t);
 
-  Aabb2 rotated(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb2 rotated(Matrix3 t, Aabb2 out) => out
+      ..copyFrom(this)
+      ..rotate(t);
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb2 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
+    Vector2.min(_min, other._min, _min);
+    Vector2.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -126,34 +152,18 @@ class Aabb2 {
   }
 
   /// Return if [this] contains [other].
-  bool containsAabb2(Aabb2 other) {
-    return min.x < other.min.x &&
-           min.y < other.min.y &&
-           max.y > other.max.y &&
-           max.x > other.max.x;
-  }
+  bool containsAabb2(Aabb2 other) => _min.x < other._min.x && _min.y <
+      other._min.y && _max.y > other._max.y && _max.x > other._max.x;
 
   /// Return if [this] contains [other].
-  bool containsVector2(Vector2 other) {
-    return min.x < other.x &&
-           min.y < other.y &&
-           max.x > other.x &&
-           max.y > other.y;
-  }
+  bool containsVector2(Vector2 other) => _min.x < other.x && _min.y < other.y &&
+      _max.x > other.x && _max.y > other.y;
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithAabb2(Aabb2 other) {
-    return min.x <= other.max.x &&
-           min.y <= other.max.y &&
-           max.x >= other.min.x &&
-           max.y >= other.min.y;
-  }
+  bool intersectsWithAabb2(Aabb2 other) => _min.x <= other._max.x && _min.y <=
+      other._max.y && _max.x >= other._min.x && _max.y >= other._min.y;
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithVector2(Vector2 other) {
-    return min.x <= other.x &&
-           min.y <= other.y &&
-           max.x >= other.x &&
-           max.y >= other.y;
-  }
+  bool intersectsWithVector2(Vector2 other) => _min.x <= other.x && _min.y <=
+      other.y && _max.x >= other.x && _max.y >= other.y;
 }

--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -21,101 +21,130 @@
 
 part of vector_math;
 
+/// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb3 {
   final Vector3 _min;
   final Vector3 _max;
 
+  /// The minimum point defining the AABB.
   Vector3 get min => _min;
+  /// The maximum point defining the AABB.
   Vector3 get max => _max;
 
-  Vector3 get center {
-    Vector3 c = new Vector3.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector3 get center => _min.clone()
+      ..add(_max)
+      ..scale(0.5);
 
-  Aabb3() :
-    _min = new Vector3.zero(),
-    _max = new Vector3.zero() {}
+  /// Create a new AABB with [min] and [max] set to the origin.
+  Aabb3()
+      : _min = new Vector3.zero(),
+        _max = new Vector3.zero();
 
-  Aabb3.copy(Aabb3 other) :
-    _min = new Vector3.copy(other._min),
-    _max = new Vector3.copy(other._max) {}
+  /// Create a new AABB as a copy of [other].
+  Aabb3.copy(Aabb3 other)
+      : _min = new Vector3.copy(other._min),
+        _max = new Vector3.copy(other._max);
 
+  /// DEPRECATED: Use [minMax] instead
   @deprecated
-  Aabb3.minmax(Vector3 min_, Vector3 max_) :
-    _min = new Vector3.copy(min_),
-    _max = new Vector3.copy(max_) {}
+  Aabb3.minmax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
-  Aabb3.minMax(Vector3 min_, Vector3 max_) :
-    _min = new Vector3.copy(min_),
-    _max = new Vector3.copy(max_) {}
+  /// Create a new AABB with a [min] and [max].
+  Aabb3.minMax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
+  /// Create a new AABB with a [center] and [max_].
+  Aabb3.centerAndHalfExtents(Vector3 center, Vector3 halfExtents)
+      : _min = new Vector3.copy(center)..sub(halfExtents),
+        _max = new Vector3.copy(center)..add(halfExtents);
+
+  /// Constructs [Aabb3] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float32List.BYTES_PER_ELEMENT].
+  Aabb3.fromBuffer(ByteBuffer buffer, int offset)
+      : _min = new Vector3.fromBuffer(buffer, offset),
+        _max = new Vector3.fromBuffer(buffer, offset +
+          Float32List.BYTES_PER_ELEMENT * 3);
+
+  /// DEPREACTED: Removed copy min and max yourself
+  @deprecated
   void copyMinMax(Vector3 min_, Vector3 max_) {
     max_.setFrom(_max);
     min_.setFrom(_min);
   }
 
-  /// Constructs Aabb3 with a min/max [storage] that views given [buffer] starting at [offset].
-  /// [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
-  Aabb3.fromBuffer(ByteBuffer buffer, int offset) : _min = new Vector3.fromBuffer(buffer, offset),
-      _max = new Vector3.fromBuffer(buffer, offset + Float32List.BYTES_PER_ELEMENT*3);
-
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+        ..setFrom(_min)
+        ..add(_max)
+        ..scale(0.5);
+    halfExtents
+        ..setFrom(_max)
+        ..sub(_min)
+        ..scale(0.5);
   }
 
-  void copyFrom(Aabb3 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb3 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb3 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [this] into [other].
+  void copyInto(Aabb3 other) {
+    other._min.setFrom(_min);
+    other._max.setFrom(_max);
   }
 
-  Aabb3 transform(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Transform [this] by the transform [t].
+  void transform(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform3(center);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t
+        ..transform3(center)
+        ..absoluteRotate(halfExtents);
+    min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb3 rotate(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  void rotate(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t.absoluteRotate(halfExtents);
+    min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb3 transformed(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb3 transformed(Matrix4 t, Aabb3 out) => out
+      ..copyFrom(this)
+      ..transform(t);
 
-  Aabb3 rotated(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb3 rotated(Matrix4 t, Aabb3 out) => out
+      ..copyFrom(this)
+      ..rotate(t);
 
+  //TODO (fox32): Add a documentation comment
   void getPN(Vector3 planeNormal, Vector3 outP, Vector3 outN) {
     outP.x = planeNormal.x < 0.0 ? _min.x : _max.x;
     outP.y = planeNormal.y < 0.0 ? _min.y : _max.y;
@@ -126,14 +155,11 @@ class Aabb3 {
     outN.z = planeNormal.z < 0.0 ? _max.z : _min.z;
   }
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb3 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    min.z = Math.min(_min.z, other.min.z);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
-    max.z = Math.max(_max.z, other.max.y);
+    Vector3.min(_min, other._min, _min);
+    Vector3.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -144,81 +170,79 @@ class Aabb3 {
 
   /// Return if [this] contains [other].
   bool containsAabb3(Aabb3 other) {
-    return min.x < other.min.x &&
-           min.y < other.min.y &&
-           min.z < other.min.z &&
-           max.x > other.max.x &&
-           max.y > other.max.y &&
-           max.z > other.max.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x < otherMin.x && _min.y < otherMin.y && _min.z < otherMin.z &&
+        _max.x > otherMax.x && _max.y > otherMax.y && _max.z > otherMax.z;
   }
 
   /// Return if [this] contains [other].
   bool containsSphere(Sphere other) {
-    final sphereExtends = new Vector3.zero().splat(other.radius);
-    final sphereBox = new Aabb3.minMax(other.center.clone().sub(sphereExtends),
-                                       other.center.clone().add(sphereExtends));
+    final boxExtends = new Vector3.all(other.radius);
+    final sphereBox = new Aabb3.centerAndHalfExtents(other.center, boxExtends);
 
     return containsAabb3(sphereBox);
   }
 
   /// Return if [this] contains [other].
   bool containsVector3(Vector3 other) {
-    return min.x < other.x &&
-           min.y < other.y &&
-           min.z < other.z &&
-           max.x > other.x &&
-           max.y > other.y &&
-           max.z > other.z;
+    final otherX = other[0];
+    final otherY = other[1];
+    final otherZ = other[2];
+
+    return _min.x < otherX && _min.y < otherY && _min.z < otherZ && _max.x >
+        otherX && _max.y > otherY && _max.z > otherZ;
   }
 
   /// Return if [this] contains [other].
-  bool containsTriangle(Triangle other) {
-    return containsVector3(other.point0) &&
-           containsVector3(other.point1) &&
-           containsVector3(other.point2);
-  }
+  bool containsTriangle(Triangle other) => containsVector3(other.point0) &&
+      containsVector3(other.point1) && containsVector3(other.point2);
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb3(Aabb3 other) {
-    return min.x <= other.max.x &&
-           min.y <= other.max.y &&
-           min.z <= other.max.z &&
-           max.x >= other.min.x &&
-           max.y >= other.min.y &&
-           max.z >= other.min.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x <= otherMax.x && _min.y <= otherMax.y && _min.z <= otherMax.z
+        && _max.x >= otherMin.x && _max.y >= otherMin.y && _max.z >= otherMin.z;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithSphere(Sphere other) {
-    double d = 0.0;
-    double e = 0.0;
+    final center = other._center;
+    final radius = other._radius;
+    var d = 0.0;
+    var e = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-      if ((e = other.center[i] - min[i]) < 0.0) {
-        if (e < -other.radius) {
+    for (var i = 0; i < 3; ++i) {
+      if ((e = center[i] - _min[i]) < 0.0) {
+        if (e < -radius) {
           return false;
         }
 
         d = d + e * e;
-      } else if ((e = other.center[i] - max[i]) > 0.0) {
-        if (e > other.radius) {
-          return false;
-        }
+      } else {
+        if ((e = center[i] - _max[i]) > 0.0) {
+          if (e > radius) {
+            return false;
+          }
 
-        d = d + e * e;
+          d = d + e * e;
+        }
       }
     }
 
-    return d <= other.radius * other.radius;
+    return d <= radius * radius;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector3(Vector3 other) {
-    return min.x <= other.x &&
-           min.y <= other.y &&
-           min.z <= other.z &&
-           max.x >= other.x &&
-           max.y >= other.y &&
-           max.z >= other.z;
+    final otherX = other[0];
+    final otherY = other[1];
+    final otherZ = other[2];
+
+    return _min.x <= otherX && _min.y <= otherY && _min.z <= otherZ && _max.x >=
+        otherX && _max.y >= otherY && _max.z >= otherZ;
   }
 }

--- a/lib/src/vector_math_64/aabb2.dart
+++ b/lib/src/vector_math_64/aabb2.dart
@@ -152,18 +152,38 @@ class Aabb2 {
   }
 
   /// Return if [this] contains [other].
-  bool containsAabb2(Aabb2 other) => _min.x < other._min.x && _min.y <
-      other._min.y && _max.y > other._max.y && _max.x > other._max.x;
+  bool containsAabb2(Aabb2 other) {
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x < otherMin.x && _min.y < otherMin.y && _max.y > otherMax.y &&
+        _max.x > otherMax.x;
+  }
 
   /// Return if [this] contains [other].
-  bool containsVector2(Vector2 other) => _min.x < other.x && _min.y < other.y &&
-      _max.x > other.x && _max.y > other.y;
+  bool containsVector2(Vector2 other) {
+    final otherX = other[0];
+    final otherY = other[1];
+
+    return _min.x < otherX && _min.y < otherY && _max.x > otherX && _max.y >
+        otherY;
+  }
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithAabb2(Aabb2 other) => _min.x <= other._max.x && _min.y <=
-      other._max.y && _max.x >= other._min.x && _max.y >= other._min.y;
+  bool intersectsWithAabb2(Aabb2 other) {
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x <= otherMax.x && _min.y <= otherMax.y && _max.x >= otherMin.x
+        && _max.y >= otherMin.y;
+  }
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithVector2(Vector2 other) => _min.x <= other.x && _min.y <=
-      other.y && _max.x >= other.x && _max.y >= other.y;
+  bool intersectsWithVector2(Vector2 other) {
+    final otherX = other[0];
+    final otherY = other[1];
+
+    return _min.x <= otherX && _min.y <= otherY && _max.x >= otherX && _max.y >=
+        otherY;
+  }
 }

--- a/lib/src/vector_math_64/aabb2.dart
+++ b/lib/src/vector_math_64/aabb2.dart
@@ -21,102 +21,128 @@
 
 part of vector_math_64;
 
+/// Defines a 2-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb2 {
   final Vector2 _min;
   final Vector2 _max;
 
+  /// The minimum point defining the AABB.
   Vector2 get min => _min;
+  /// The maximum point defining the AABB.
   Vector2 get max => _max;
 
-  Vector2 get center {
-    Vector2 c = new Vector2.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector2 get center => _min.clone()
+      ..add(_max)
+      ..scale(0.5);
 
-  Aabb2() :
-    _min = new Vector2.zero(),
-    _max = new Vector2.zero() {}
+  /// Create a new AABB with [min] and [max] set to the origin.
+  Aabb2()
+      : _min = new Vector2.zero(),
+        _max = new Vector2.zero();
 
-  Aabb2.copy(Aabb2 other) :
-    _min = new Vector2.copy(other._min),
-    _max = new Vector2.copy(other._max) {}
+  /// Create a new AABB as a copy of [other].
+  Aabb2.copy(Aabb2 other)
+      : _min = new Vector2.copy(other._min),
+        _max = new Vector2.copy(other._max);
 
+  /// DEPREACTED: Use [minMax] instead.
   @deprecated
-  Aabb2.minmax(Vector2 min_, Vector2 max_) :
-    _min = new Vector2.copy(min_),
-    _max = new Vector2.copy(max_) {}
+  Aabb2.minmax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  Aabb2.minMax(Vector2 min_, Vector2 max_) :
-    _min = new Vector2.copy(min_),
-    _max = new Vector2.copy(max_) {}
+  /// Create a new AABB with a [min] and [max].
+  Aabb2.minMax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  void copyMinMax(Vector2 min_, Vector2 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
+  /// Create a new AABB with a [center] and [halfExtents].
+  Aabb2.centerAndHalfExtents(Vector2 center, Vector2 halfExtents)
+      : _min = new Vector2.copy(center)..sub(halfExtents),
+        _max = new Vector2.copy(center)..add(halfExtents);
+
+  //TODO (fox32): A fromBuffer constructor is missing here?
+
+  /// DEPREACTED: Removed copy min and max yourself
+  @deprecated
+  void copyMinMax(Vector2 min, Vector2 max) {
+    max.setFrom(_max);
+    min.setFrom(_min);
   }
 
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+        ..setFrom(_min)
+        ..add(_max)
+        ..scale(0.5);
+    halfExtents
+        ..setFrom(_max)
+        ..sub(_min)
+        ..scale(0.5);
   }
 
-  void copyFrom(Aabb2 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb2 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb2 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [this] into [other].
+  void copyInto(Aabb2 other) {
+    other._min.setFrom(_min);
+    other._max.setFrom(_max);
   }
 
-  Aabb2 transform(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Transform [this] by the transform [t].
+  void transform(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform2(center);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t
+        ..transform2(center)
+        ..absoluteRotate2(halfExtents);
+    _min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    _max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb2 rotate(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  void rotate(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t.absoluteRotate2(halfExtents);
+    _min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    _max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb2 transformed(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb2 transformed(Matrix3 t, Aabb2 out) => out
+      ..copyFrom(this)
+      ..transform(t);
 
-  Aabb2 rotated(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb2 rotated(Matrix3 t, Aabb2 out) => out
+      ..copyFrom(this)
+      ..rotate(t);
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb2 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
+    Vector2.min(_min, other._min, _min);
+    Vector2.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -126,34 +152,18 @@ class Aabb2 {
   }
 
   /// Return if [this] contains [other].
-  bool containsAabb2(Aabb2 other) {
-    return min.x < other.min.x &&
-           min.y < other.min.y &&
-           max.y > other.max.y &&
-           max.x > other.max.x;
-  }
+  bool containsAabb2(Aabb2 other) => _min.x < other._min.x && _min.y <
+      other._min.y && _max.y > other._max.y && _max.x > other._max.x;
 
   /// Return if [this] contains [other].
-  bool containsVector2(Vector2 other) {
-    return min.x < other.x &&
-           min.y < other.y &&
-           max.x > other.x &&
-           max.y > other.y;
-  }
+  bool containsVector2(Vector2 other) => _min.x < other.x && _min.y < other.y &&
+      _max.x > other.x && _max.y > other.y;
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithAabb2(Aabb2 other) {
-    return min.x <= other.max.x &&
-           min.y <= other.max.y &&
-           max.x >= other.min.x &&
-           max.y >= other.min.y;
-  }
+  bool intersectsWithAabb2(Aabb2 other) => _min.x <= other._max.x && _min.y <=
+      other._max.y && _max.x >= other._min.x && _max.y >= other._min.y;
 
   /// Return if [this] intersects with [other].
-  bool intersectsWithVector2(Vector2 other) {
-    return min.x <= other.x &&
-           min.y <= other.y &&
-           max.x >= other.x &&
-           max.y >= other.y;
-  }
+  bool intersectsWithVector2(Vector2 other) => _min.x <= other.x && _min.y <=
+      other.y && _max.x >= other.x && _max.y >= other.y;
 }

--- a/lib/src/vector_math_64/aabb3.dart
+++ b/lib/src/vector_math_64/aabb3.dart
@@ -21,101 +21,130 @@
 
 part of vector_math_64;
 
+/// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb3 {
   final Vector3 _min;
   final Vector3 _max;
 
+  /// The minimum point defining the AABB.
   Vector3 get min => _min;
+  /// The maximum point defining the AABB.
   Vector3 get max => _max;
 
-  Vector3 get center {
-    Vector3 c = new Vector3.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector3 get center => _min.clone()
+      ..add(_max)
+      ..scale(0.5);
 
-  Aabb3() :
-    _min = new Vector3.zero(),
-    _max = new Vector3.zero() {}
+  /// Create a new AABB with [min] and [max] set to the origin.
+  Aabb3()
+      : _min = new Vector3.zero(),
+        _max = new Vector3.zero();
 
-  Aabb3.copy(Aabb3 other) :
-    _min = new Vector3.copy(other._min),
-    _max = new Vector3.copy(other._max) {}
+  /// Create a new AABB as a copy of [other].
+  Aabb3.copy(Aabb3 other)
+      : _min = new Vector3.copy(other._min),
+        _max = new Vector3.copy(other._max);
 
+  /// DEPRECATED: Use [minMax] instead
   @deprecated
-  Aabb3.minmax(Vector3 min_, Vector3 max_) :
-    _min = new Vector3.copy(min_),
-    _max = new Vector3.copy(max_) {}
+  Aabb3.minmax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
-  Aabb3.minMax(Vector3 min_, Vector3 max_) :
-    _min = new Vector3.copy(min_),
-    _max = new Vector3.copy(max_) {}
+  /// Create a new AABB with a [min] and [max].
+  Aabb3.minMax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
+  /// Create a new AABB with a [center] and [max_].
+  Aabb3.centerAndHalfExtents(Vector3 center, Vector3 halfExtents)
+      : _min = new Vector3.copy(center)..sub(halfExtents),
+        _max = new Vector3.copy(center)..add(halfExtents);
+
+  /// Constructs [Aabb3] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float64List.BYTES_PER_ELEMENT].
+  Aabb3.fromBuffer(ByteBuffer buffer, int offset)
+      : _min = new Vector3.fromBuffer(buffer, offset),
+        _max = new Vector3.fromBuffer(buffer, offset +
+          Float64List.BYTES_PER_ELEMENT * 3);
+
+  /// DEPREACTED: Removed copy min and max yourself
+  @deprecated
   void copyMinMax(Vector3 min_, Vector3 max_) {
     max_.setFrom(_max);
     min_.setFrom(_min);
   }
 
-  /// Constructs Aabb3 with a min/max [storage] that views given [buffer] starting at [offset].
-  /// [offset] has to be multiple of [Float64List.BYTES_PER_ELEMENT].
-  Aabb3.fromBuffer(ByteBuffer buffer, int offset) : _min = new Vector3.fromBuffer(buffer, offset),
-      _max = new Vector3.fromBuffer(buffer, offset + Float64List.BYTES_PER_ELEMENT*3);
-
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+        ..setFrom(_min)
+        ..add(_max)
+        ..scale(0.5);
+    halfExtents
+        ..setFrom(_max)
+        ..sub(_min)
+        ..scale(0.5);
   }
 
-  void copyFrom(Aabb3 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb3 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb3 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [this] into [other].
+  void copyInto(Aabb3 other) {
+    other._min.setFrom(_min);
+    other._max.setFrom(_max);
   }
 
-  Aabb3 transform(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Transform [this] by the transform [t].
+  void transform(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform3(center);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t
+        ..transform3(center)
+        ..absoluteRotate(halfExtents);
+    min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb3 rotate(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  void rotate(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
-    return this;
+    t.absoluteRotate(halfExtents);
+    min
+        ..setFrom(center)
+        ..sub(halfExtents);
+    max
+        ..setFrom(center)
+        ..add(halfExtents);
   }
 
-  Aabb3 transformed(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb3 transformed(Matrix4 t, Aabb3 out) => out
+      ..copyFrom(this)
+      ..transform(t);
 
-  Aabb3 rotated(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb3 rotated(Matrix4 t, Aabb3 out) => out
+      ..copyFrom(this)
+      ..rotate(t);
 
+  //TODO (fox32): Add a documentation comment
   void getPN(Vector3 planeNormal, Vector3 outP, Vector3 outN) {
     outP.x = planeNormal.x < 0.0 ? _min.x : _max.x;
     outP.y = planeNormal.y < 0.0 ? _min.y : _max.y;
@@ -126,14 +155,11 @@ class Aabb3 {
     outN.z = planeNormal.z < 0.0 ? _max.z : _min.z;
   }
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb3 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    min.z = Math.min(_min.z, other.min.z);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
-    max.z = Math.max(_max.z, other.max.y);
+    Vector3.min(_min, other._min, _min);
+    Vector3.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -144,81 +170,79 @@ class Aabb3 {
 
   /// Return if [this] contains [other].
   bool containsAabb3(Aabb3 other) {
-    return min.x < other.min.x &&
-           min.y < other.min.y &&
-           min.z < other.min.z &&
-           max.x > other.max.x &&
-           max.y > other.max.y &&
-           max.z > other.max.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x < otherMin.x && _min.y < otherMin.y && _min.z < otherMin.z &&
+        _max.x > otherMax.x && _max.y > otherMax.y && _max.z > otherMax.z;
   }
 
   /// Return if [this] contains [other].
   bool containsSphere(Sphere other) {
-    final sphereExtends = new Vector3.zero().splat(other.radius);
-    final sphereBox = new Aabb3.minMax(other.center.clone().sub(sphereExtends),
-                                       other.center.clone().add(sphereExtends));
+    final boxExtends = new Vector3.all(other.radius);
+    final sphereBox = new Aabb3.centerAndHalfExtents(other.center, boxExtends);
 
     return containsAabb3(sphereBox);
   }
 
   /// Return if [this] contains [other].
   bool containsVector3(Vector3 other) {
-    return min.x < other.x &&
-           min.y < other.y &&
-           min.z < other.z &&
-           max.x > other.x &&
-           max.y > other.y &&
-           max.z > other.z;
+    final otherX = other[0];
+    final otherY = other[1];
+    final otherZ = other[2];
+
+    return _min.x < otherX && _min.y < otherY && _min.z < otherZ && _max.x >
+        otherX && _max.y > otherY && _max.z > otherZ;
   }
 
   /// Return if [this] contains [other].
-  bool containsTriangle(Triangle other) {
-    return containsVector3(other.point0) &&
-           containsVector3(other.point1) &&
-           containsVector3(other.point2);
-  }
+  bool containsTriangle(Triangle other) => containsVector3(other.point0) &&
+      containsVector3(other.point1) && containsVector3(other.point2);
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb3(Aabb3 other) {
-    return min.x <= other.max.x &&
-           min.y <= other.max.y &&
-           min.z <= other.max.z &&
-           max.x >= other.min.x &&
-           max.y >= other.min.y &&
-           max.z >= other.min.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return _min.x <= otherMax.x && _min.y <= otherMax.y && _min.z <= otherMax.z
+        && _max.x >= otherMin.x && _max.y >= otherMin.y && _max.z >= otherMin.z;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithSphere(Sphere other) {
-    double d = 0.0;
-    double e = 0.0;
+    final center = other._center;
+    final radius = other._radius;
+    var d = 0.0;
+    var e = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-      if ((e = other.center[i] - min[i]) < 0.0) {
-        if (e < -other.radius) {
+    for (var i = 0; i < 3; ++i) {
+      if ((e = center[i] - _min[i]) < 0.0) {
+        if (e < -radius) {
           return false;
         }
 
         d = d + e * e;
-      } else if ((e = other.center[i] - max[i]) > 0.0) {
-        if (e > other.radius) {
-          return false;
-        }
+      } else {
+        if ((e = center[i] - _max[i]) > 0.0) {
+          if (e > radius) {
+            return false;
+          }
 
-        d = d + e * e;
+          d = d + e * e;
+        }
       }
     }
 
-    return d <= other.radius * other.radius;
+    return d <= radius * radius;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector3(Vector3 other) {
-    return min.x <= other.x &&
-           min.y <= other.y &&
-           min.z <= other.z &&
-           max.x >= other.x &&
-           max.y >= other.y &&
-           max.z >= other.z;
+    final otherX = other[0];
+    final otherY = other[1];
+    final otherZ = other[2];
+
+    return _min.x <= otherX && _min.y <= otherY && _min.z <= otherZ && _max.x >=
+        otherX && _max.y >= otherY && _max.z >= otherZ;
   }
 }

--- a/test/test_aabb.dart
+++ b/test/test_aabb.dart
@@ -115,7 +115,7 @@ class AabbTest extends BaseTest {
     final Matrix3 rotation = new Matrix3.rotationZ(Math.PI/4);
     final Aabb2 input = new Aabb2.minMax(_v(1.0,1.0), _v(3.0,3.0));
 
-    final Aabb2 result = input.rotate(rotation);
+    final Aabb2 result = input..rotate(rotation);
 
     relativeTest(result.min.x, 2-Math.sqrt(2));
     relativeTest(result.min.y, 2-Math.sqrt(2));
@@ -129,7 +129,7 @@ class AabbTest extends BaseTest {
     final Matrix3 rotation = new Matrix3.rotationZ(Math.PI/4);
     final Aabb2 input = new Aabb2.minMax(_v(1.0,1.0), _v(3.0,3.0));
 
-    final Aabb2 result = input.transform(rotation);
+    final Aabb2 result = input..transform(rotation);
     final double newCenterY = Math.sqrt(8);
 
     relativeTest(result.min.x, -Math.sqrt(2));


### PR DESCRIPTION
I tried to split up my PR by feature, but that is hard (to much work). My current plan is to send many small PRs that go chronological through my big PR. I try to do group together commits that make sense. But this means that I may have things that aren't 'perfect' after this PR, but a later PR will fix this.

Remove call chaining from the AABB classes. I also fixed the indention for constructors, but I screw it up for the containsAabb methods. I tried to fix it, but it will make later pull requests more difficult due to merge conflicts as I already fixed it in a later commit that is not included here.

Aabb2.fromBuffer is missing in this PR, but I have a later one that will add it to have a equal interface for 2 and 3 dimensional AABBs. I have to add Vector2.fromBuffer first.

Always using the private variables is related to a later PR and improvments for dart2js. A later PR will rename the private variables, so that they are unique for every class in this library.