### PR TITLE
Feature/fix vector list stride

### DIFF
--- a/lib/src/vector_math_lists/vector.dart
+++ b/lib/src/vector_math_lists/vector.dart
@@ -65,7 +65,7 @@ abstract class VectorList<T extends Vector> {
       : _vectorLength = vectorLength,
         _offset = offset,
         _stride = stride == 0 ? vectorLength : stride,
-        _length = (buffer.length - offset) ~/
+        _length = (buffer.length - Math.max(0, offset - stride)) ~/
             (stride == 0 ? vectorLength : stride),
         _buffer = buffer {
     if (_stride < _vectorLength) {

--- a/test/vector2_list_test.dart
+++ b/test/vector2_list_test.dart
@@ -14,75 +14,77 @@ import 'package:vector_math/vector_math_lists.dart';
 import 'test_utils.dart';
 
 void main() {
-  test('Vector2List with offset', () {
-    Vector2List list = new Vector2List(10, 1);
-    list[0] = new Vector2(1.0, 2.0);
-    relativeTest(list[0].x, 1.0);
-    relativeTest(list[0].y, 2.0);
-    relativeTest(list.buffer[0], 0.0); // unset
-    relativeTest(list.buffer[1], 1.0);
-    relativeTest(list.buffer[2], 2.0);
-    relativeTest(list.buffer[3], 0.0); // unset
-  });
+  group('Vector2List', () {
+    test('Vector2List with offset', () {
+      Vector2List list = new Vector2List(10, 1);
+      list[0] = new Vector2(1.0, 2.0);
+      relativeTest(list[0].x, 1.0);
+      relativeTest(list[0].y, 2.0);
+      relativeTest(list.buffer[0], 0.0); // unset
+      relativeTest(list.buffer[1], 1.0);
+      relativeTest(list.buffer[2], 2.0);
+      relativeTest(list.buffer[3], 0.0); // unset
+    });
 
-  test('Vector2List.view', () {
-    Float32List buffer = new Float32List(8);
-    Vector2List list = new Vector2List.view(buffer, 1, 3);
-    // The list length should be (8 - 1) ~/ 3 == 2.
-    expect(list.length, 2);
-    list[0] = new Vector2(1.0, 2.0);
-    list[1] = new Vector2(3.0, 4.0);
-    expect(buffer[0], 0.0);
-    expect(buffer[1], 1.0);
-    expect(buffer[2], 2.0);
-    expect(buffer[3], 0.0);
-    expect(buffer[4], 3.0);
-    expect(buffer[5], 4.0);
-    expect(buffer[6], 0.0);
-    expect(buffer[7], 0.0);
-  });
+    test('Vector2List.view', () {
+      Float32List buffer = new Float32List(8);
+      Vector2List list = new Vector2List.view(buffer, 1, 3);
+      // The list length should be (8 - 1) ~/ 3 == 2.
+      expect(list.length, 2);
+      list[0] = new Vector2(1.0, 2.0);
+      list[1] = new Vector2(3.0, 4.0);
+      expect(buffer[0], 0.0);
+      expect(buffer[1], 1.0);
+      expect(buffer[2], 2.0);
+      expect(buffer[3], 0.0);
+      expect(buffer[4], 3.0);
+      expect(buffer[5], 4.0);
+      expect(buffer[6], 0.0);
+      expect(buffer[7], 0.0);
+    });
 
-  test('Vector2List.view tight fit', () {
-    Float32List buffer = new Float32List(8);
-    Vector2List list = new Vector2List.view(buffer, 2, 4);
-    // The list length should be (8 - 2) ~/ 2 == 2 as the stride of the last
-    // element is negligible.
-    expect(list.length, 2);
-    list[0] = new Vector2(1.0, 2.0);
-    list[1] = new Vector2(3.0, 4.0);
-    expect(buffer[0], 0.0);
-    expect(buffer[1], 0.0);
-    expect(buffer[2], 1.0);
-    expect(buffer[3], 2.0);
-    expect(buffer[4], 0.0);
-    expect(buffer[5], 0.0);
-    expect(buffer[6], 3.0);
-    expect(buffer[7], 4.0);
-  });
+    test('Vector2List.view tight fit', () {
+      Float32List buffer = new Float32List(8);
+      Vector2List list = new Vector2List.view(buffer, 2, 4);
+      // The list length should be (8 - 2) ~/ 2 == 2 as the stride of the last
+      // element is negligible.
+      expect(list.length, 2);
+      list[0] = new Vector2(1.0, 2.0);
+      list[1] = new Vector2(3.0, 4.0);
+      expect(buffer[0], 0.0);
+      expect(buffer[1], 0.0);
+      expect(buffer[2], 1.0);
+      expect(buffer[3], 2.0);
+      expect(buffer[4], 0.0);
+      expect(buffer[5], 0.0);
+      expect(buffer[6], 3.0);
+      expect(buffer[7], 4.0);
+    });
 
-  test('Vector2List.fromList', () {
-    List<Vector2> input = new List<Vector2>(3);
-    input[0] = new Vector2(1.0, 2.0);
-    input[1] = new Vector2(3.0, 4.0);
-    input[2] = new Vector2(5.0, 6.0);
-    Vector2List list = new Vector2List.fromList(input, 2, 5);
-    expect(list.buffer.length, 17);
-    expect(list.buffer[0], 0.0);
-    expect(list.buffer[1], 0.0);
-    expect(list.buffer[2], 1.0);
-    expect(list.buffer[3], 2.0);
-    expect(list.buffer[4], 0.0);
-    expect(list.buffer[5], 0.0);
-    expect(list.buffer[6], 0.0);
-    expect(list.buffer[7], 3.0);
-    expect(list.buffer[8], 4.0);
-    expect(list.buffer[9], 0.0);
-    expect(list.buffer[10], 0.0);
-    expect(list.buffer[11], 0.0);
-    expect(list.buffer[12], 5.0);
-    expect(list.buffer[13], 6.0);
-    expect(list.buffer[14], 0.0);
-    expect(list.buffer[15], 0.0);
-    expect(list.buffer[16], 0.0);
+    test('Vector2List.fromList', () {
+      List<Vector2> input = new List<Vector2>(3);
+      input[0] = new Vector2(1.0, 2.0);
+      input[1] = new Vector2(3.0, 4.0);
+      input[2] = new Vector2(5.0, 6.0);
+      Vector2List list = new Vector2List.fromList(input, 2, 5);
+      expect(list.buffer.length, 17);
+      expect(list.buffer[0], 0.0);
+      expect(list.buffer[1], 0.0);
+      expect(list.buffer[2], 1.0);
+      expect(list.buffer[3], 2.0);
+      expect(list.buffer[4], 0.0);
+      expect(list.buffer[5], 0.0);
+      expect(list.buffer[6], 0.0);
+      expect(list.buffer[7], 3.0);
+      expect(list.buffer[8], 4.0);
+      expect(list.buffer[9], 0.0);
+      expect(list.buffer[10], 0.0);
+      expect(list.buffer[11], 0.0);
+      expect(list.buffer[12], 5.0);
+      expect(list.buffer[13], 6.0);
+      expect(list.buffer[14], 0.0);
+      expect(list.buffer[15], 0.0);
+      expect(list.buffer[16], 0.0);
+    });
   });
 }

--- a/test/vector2_list_test.dart
+++ b/test/vector2_list_test.dart
@@ -42,6 +42,24 @@ void main() {
     expect(buffer[7], 0.0);
   });
 
+  test('Vector2List.view tight fit', () {
+    Float32List buffer = new Float32List(8);
+    Vector2List list = new Vector2List.view(buffer, 2, 4);
+    // The list length should be (8 - 2) ~/ 2 == 2 as the stride of the last
+    // element is negligible.
+    expect(list.length, 2);
+    list[0] = new Vector2(1.0, 2.0);
+    list[1] = new Vector2(3.0, 4.0);
+    expect(buffer[0], 0.0);
+    expect(buffer[1], 0.0);
+    expect(buffer[2], 1.0);
+    expect(buffer[3], 2.0);
+    expect(buffer[4], 0.0);
+    expect(buffer[5], 0.0);
+    expect(buffer[6], 3.0);
+    expect(buffer[7], 4.0);
+  });
+
   test('Vector2List.fromList', () {
     List<Vector2> input = new List<Vector2>(3);
     input[0] = new Vector2(1.0, 2.0);

--- a/test/vector2_list_test.dart
+++ b/test/vector2_list_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library vector_math.test.vector2_list_test;
+
+import 'dart:typed_data';
+
+import 'package:unittest/unittest.dart';
+
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_math/vector_math_lists.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('Vector2List with offset', () {
+    Vector2List list = new Vector2List(10, 1);
+    list[0] = new Vector2(1.0, 2.0);
+    relativeTest(list[0].x, 1.0);
+    relativeTest(list[0].y, 2.0);
+    relativeTest(list.buffer[0], 0.0); // unset
+    relativeTest(list.buffer[1], 1.0);
+    relativeTest(list.buffer[2], 2.0);
+    relativeTest(list.buffer[3], 0.0); // unset
+  });
+
+  test('Vector2List.view', () {
+    Float32List buffer = new Float32List(8);
+    Vector2List list = new Vector2List.view(buffer, 1, 3);
+    // The list length should be (8 - 1) ~/ 3 == 2.
+    expect(list.length, 2);
+    list[0] = new Vector2(1.0, 2.0);
+    list[1] = new Vector2(3.0, 4.0);
+    expect(buffer[0], 0.0);
+    expect(buffer[1], 1.0);
+    expect(buffer[2], 2.0);
+    expect(buffer[3], 0.0);
+    expect(buffer[4], 3.0);
+    expect(buffer[5], 4.0);
+    expect(buffer[6], 0.0);
+    expect(buffer[7], 0.0);
+  });
+
+  test('Vector2List.fromList', () {
+    List<Vector2> input = new List<Vector2>(3);
+    input[0] = new Vector2(1.0, 2.0);
+    input[1] = new Vector2(3.0, 4.0);
+    input[2] = new Vector2(5.0, 6.0);
+    Vector2List list = new Vector2List.fromList(input, 2, 5);
+    expect(list.buffer.length, 17);
+    expect(list.buffer[0], 0.0);
+    expect(list.buffer[1], 0.0);
+    expect(list.buffer[2], 1.0);
+    expect(list.buffer[3], 2.0);
+    expect(list.buffer[4], 0.0);
+    expect(list.buffer[5], 0.0);
+    expect(list.buffer[6], 0.0);
+    expect(list.buffer[7], 3.0);
+    expect(list.buffer[8], 4.0);
+    expect(list.buffer[9], 0.0);
+    expect(list.buffer[10], 0.0);
+    expect(list.buffer[11], 0.0);
+    expect(list.buffer[12], 5.0);
+    expect(list.buffer[13], 6.0);
+    expect(list.buffer[14], 0.0);
+    expect(list.buffer[15], 0.0);
+    expect(list.buffer[16], 0.0);
+  });
+}

--- a/test/vector_test.dart
+++ b/test/vector_test.dart
@@ -10,7 +10,6 @@ import 'dart:math' as Math;
 import 'package:unittest/unittest.dart';
 
 import 'package:vector_math/vector_math.dart';
-import 'package:vector_math/vector_math_lists.dart';
 
 import 'test_utils.dart';
 
@@ -618,60 +617,6 @@ void testVec3AngleToSigned() {
   expect(v1.angleToSigned(v0, n), equals(-Math.PI / 2.0));
 }
 
-void testVec2List() {
-  {
-    Vector2List list = new Vector2List(10, 1);
-    list[0] = new Vector2(1.0, 2.0);
-    relativeTest(list[0].x, 1.0);
-    relativeTest(list[0].y, 2.0);
-    relativeTest(list.buffer[0], 0.0); // unset
-    relativeTest(list.buffer[1], 1.0);
-    relativeTest(list.buffer[2], 2.0);
-    relativeTest(list.buffer[3], 0.0); // unset
-  }
-  {
-    Float32List buffer = new Float32List(8);
-    Vector2List list = new Vector2List.view(buffer, 1, 3);
-    // The list length should be (8 - 1) ~/ 3 == 2.
-    expect(list.length, 2);
-    list[0] = new Vector2(1.0, 2.0);
-    list[1] = new Vector2(3.0, 4.0);
-    expect(buffer[0], 0.0);
-    expect(buffer[1], 1.0);
-    expect(buffer[2], 2.0);
-    expect(buffer[3], 0.0);
-    expect(buffer[4], 3.0);
-    expect(buffer[5], 4.0);
-    expect(buffer[6], 0.0);
-    expect(buffer[7], 0.0);
-  }
-  {
-    List<Vector2> input = new List<Vector2>(3);
-    input[0] = new Vector2(1.0, 2.0);
-    input[1] = new Vector2(3.0, 4.0);
-    input[2] = new Vector2(5.0, 6.0);
-    Vector2List list = new Vector2List.fromList(input, 2, 5);
-    expect(list.buffer.length, 17);
-    expect(list.buffer[0], 0.0);
-    expect(list.buffer[1], 0.0);
-    expect(list.buffer[2], 1.0);
-    expect(list.buffer[3], 2.0);
-    expect(list.buffer[4], 0.0);
-    expect(list.buffer[5], 0.0);
-    expect(list.buffer[6], 0.0);
-    expect(list.buffer[7], 3.0);
-    expect(list.buffer[8], 4.0);
-    expect(list.buffer[9], 0.0);
-    expect(list.buffer[10], 0.0);
-    expect(list.buffer[11], 0.0);
-    expect(list.buffer[12], 5.0);
-    expect(list.buffer[13], 6.0);
-    expect(list.buffer[14], 0.0);
-    expect(list.buffer[15], 0.0);
-    expect(list.buffer[16], 0.0);
-  }
-}
-
 void main() {
   test('2D dot product', testVec2DotProduct);
   test('2D postmultiplication', testVec2Postmultiplication);
@@ -718,6 +663,4 @@ void main() {
 
   test('3D instancing from Float32List', testVec3InstacinfFromFloat32List);
   test('3D instancing from ByteBuffer', testVec3InstacingFromByteBuffer);
-
-  test('Vector2 list', testVec2List);
 }


### PR DESCRIPTION
Often one ones to use a VectorList of interleaved vertex buffers. Then every attribute of a vertex has an own list, like:

```
final vertex = new Float32List(12);
final vertexPositions = new Vector3List.view(usedVertexData, 0, 6);
final vertexNormals = new Vector3List.view(usedVertexData, 3, 6);

// A list of the lenght 12 should be able to contain 2 vertices if they have a stride of 6
```

Previously, creating the vertexNormals with the right length was not possible as it was expected that  also the last element's stride was available.