### PR TITLE
Add a method for copying the rotation part of a Matrix4

### DIFF
--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1130,16 +1130,22 @@ class Matrix4 {
   /// Returns the rotation matrix from this homogeneous transformation matrix.
   Matrix3 getRotation() {
     Matrix3 r = new Matrix3.zero();
-    r.storage[0] = storage[0];
-    r.storage[1] = storage[1];
-    r.storage[2] = storage[2];
-    r.storage[3] = storage[4];
-    r.storage[4] = storage[5];
-    r.storage[5] = storage[6];
-    r.storage[6] = storage[8];
-    r.storage[7] = storage[9];
-    r.storage[8] = storage[10];
+    copyRotation(r);
     return r;
+  }
+
+  /// Copies the rotation matrix from this homogeneous transformation matrix
+  /// into [rotation].
+  void copyRotation(Matrix3 rotation) {
+    rotation.storage[0] = storage[0];
+    rotation.storage[1] = storage[1];
+    rotation.storage[2] = storage[2];
+    rotation.storage[3] = storage[4];
+    rotation.storage[4] = storage[5];
+    rotation.storage[5] = storage[6];
+    rotation.storage[6] = storage[8];
+    rotation.storage[7] = storage[9];
+    rotation.storage[8] = storage[10];
   }
 
   /// Sets the rotation matrix in this homogeneous transformation matrix.

--- a/test/matrix_test.dart
+++ b/test/matrix_test.dart
@@ -546,6 +546,18 @@ void testRotateMatrix() {
   return;
 }
 
+void testGetRotationMatrix() {
+  final mat4 = new Matrix4.rotationX(Math.PI) *
+      new Matrix4.rotationY(-Math.PI) *
+      new Matrix4.rotationZ(Math.PI);
+  final mat3 = new Matrix3.rotationX(Math.PI) *
+      new Matrix3.rotationY(-Math.PI) *
+      new Matrix3.rotationZ(Math.PI);
+  final matRot = mat4.getRotation();
+
+  relativeTest(mat3, matRot);
+}
+
 void testMat2Transform() {
   var rot = new Matrix2.rotation(Math.PI / 4);
   final input = new Vector2(0.234245234259, 0.890723489233);
@@ -806,6 +818,7 @@ void main() {
   test('Matrix translate', testTranslationMatrix);
   test('Scale matrix', testScaleMatrix);
   test('Rotate matrix', testRotateMatrix);
+  test('Get rotation matrix', testGetRotationMatrix);
   test('2D transform', testMat2Transform);
   test('Matrix3 2D transform', testMatrix3Transform2);
   test('Matrix3 2D rotation', testMatrix3AbsoluteRotate2);


### PR DESCRIPTION
There was already a getter available but it retured a new instance and doesn't allow to reuse a existing Matrix3.
Also added a test