### PR TITLE
Rename constants back to lowerCase

### DIFF
--- a/lib/src/vector_math/constants.dart
+++ b/lib/src/vector_math/constants.dart
@@ -5,16 +5,7 @@
 part of vector_math;
 
 /// Constant factor to convert and angle from degrees to radians.
-const double DEGREES_2_RADIANS = Math.PI / 180.0;
+const double degrees2Radians = Math.PI / 180.0;
 /// Constant factor to convert and angle from radians to degrees.
-const double RADIANS_2_DEGREES = 180.0 / Math.PI;
+const double radians2Degrees = 180.0 / Math.PI;
 
-/// DEPRECATED: Use DEGREES_2_RADIANS instead
-@deprecated
-const double degrees2radians = Math.PI / 180.0;
-/// DEPRECATED: Use RADIANS_2_DEGREES instead
-@deprecated
-const double radians2degrees = 180.0 / Math.PI;
-/// DEPRECATED: Use SQRT1_2 from dart:math instead
-@deprecated
-const double sqrtOneHalf = 0.70710678118;

--- a/lib/src/vector_math/utilities.dart
+++ b/lib/src/vector_math/utilities.dart
@@ -6,12 +6,12 @@ part of vector_math;
 
 /// Convert [radians] to degrees.
 double degrees(double radians) {
-  return radians * RADIANS_2_DEGREES;
+  return radians * radians2Degrees;
 }
 
 /// Convert [degrees] to radians.
 double radians(double degrees) {
-  return degrees * DEGREES_2_RADIANS;
+  return degrees * degrees2Radians;
 }
 
 /// Interpolate between [min] and [max] with the amount of [a] using a linear

--- a/lib/src/vector_math_64/constants.dart
+++ b/lib/src/vector_math_64/constants.dart
@@ -5,16 +5,7 @@
 part of vector_math_64;
 
 /// Constant factor to convert and angle from degrees to radians.
-const double DEGREES_2_RADIANS = Math.PI / 180.0;
+const double degrees2Radians = Math.PI / 180.0;
 /// Constant factor to convert and angle from radians to degrees.
-const double RADIANS_2_DEGREES = 180.0 / Math.PI;
+const double radians2Degrees = 180.0 / Math.PI;
 
-/// DEPRECATED: Use DEGREES_2_RADIANS instead
-@deprecated
-const double degrees2radians = Math.PI / 180.0;
-/// DEPRECATED: Use RADIANS_2_DEGREES instead
-@deprecated
-const double radians2degrees = 180.0 / Math.PI;
-/// DEPRECATED: Use SQRT1_2 from dart:math instead
-@deprecated
-const double sqrtOneHalf = 0.70710678118;

--- a/lib/src/vector_math_64/utilities.dart
+++ b/lib/src/vector_math_64/utilities.dart
@@ -6,12 +6,12 @@ part of vector_math_64;
 
 /// Convert [radians] to degrees.
 double degrees(double radians) {
-  return radians * RADIANS_2_DEGREES;
+  return radians * radians2Degrees;
 }
 
 /// Convert [degrees] to radians.
 double radians(double degrees) {
-  return degrees * DEGREES_2_RADIANS;
+  return degrees * degrees2Radians;
 }
 
 /// Interpolate between [min] and [max] with the amount of [a] using a linear

--- a/lib/vector_math.dart
+++ b/lib/vector_math.dart
@@ -2,6 +2,21 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// A library containing different type of vector operations for use in games,
+/// simulations, or rendering.
+///
+/// The library contains Vector classes ([Vector2], [Vector3] and [Vector4]),
+/// Matrices classes ([Matrix2], [Matrix3] and [Matrix4]) and collision
+/// detection related classes ([Aabb2], [Aabb3], [Frustum], [Obb3], [Plane],
+/// [Quad], [Ray], [Sphere] and [Triangle]).
+///
+/// In addition some utilities are avialable as color operations (See [Colors]
+/// class), noise generators ([SimplexNoise]) and common OpenGL operations
+/// (like [makeViewMatrix], [makePerspectiveMatrix], or [pickRay]).
+///
+/// There is also a [vector_math_64] library available that uses double
+/// precision (64-bit) instead of single precision (32-bit) floating point
+/// numbers for storage.
 library vector_math;
 
 import 'dart:typed_data';

--- a/lib/vector_math_64.dart
+++ b/lib/vector_math_64.dart
@@ -2,6 +2,21 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// A library containing different type of vector operations for use in games,
+/// simulations, or rendering.
+///
+/// The library contains Vector classes ([Vector2], [Vector3] and [Vector4]),
+/// Matrices classes ([Matrix2], [Matrix3] and [Matrix4]) and collision
+/// detection related classes ([Aabb2], [Aabb3], [Frustum], [Obb3], [Plane],
+/// [Quad], [Ray], [Sphere] and [Triangle]).
+///
+/// In addition some utilities are avialable as color operations (See [Colors]
+/// class), noise generators ([SimplexNoise]) and common OpenGL operations
+/// (like [makeViewMatrix], [makePerspectiveMatrix], or [pickRay]).
+///
+/// There is also a [vector_math_64_64] library available that uses double
+/// precision (64-bit) instead of single precision (32-bit) floating point
+/// numbers for storage.
 library vector_math_64;
 
 import 'dart:typed_data';

--- a/lib/vector_math_geometry.dart
+++ b/lib/vector_math_geometry.dart
@@ -2,6 +2,9 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// A library containing geometry generators (like [CubeGenerator],
+/// [SphereGenerator] and [CylinderGenerator]) and filters ([BarycentricFilter],
+/// [ColorFilter] and [InvertFilter]).
 library vector_math_geometry;
 
 import 'dart:typed_data';

--- a/lib/vector_math_lists.dart
+++ b/lib/vector_math_lists.dart
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /// A library for working with lists of vectors in a memory efficient way.
+
 library vector_math_lists;
 
 import 'dart:typed_data';

--- a/lib/vector_math_operations.dart
+++ b/lib/vector_math_operations.dart
@@ -2,6 +2,10 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// A library containing matrix operations ([Matrix44Operations]) that can be
+/// performed on [Float32List] instances and SIMD optimized operations
+/// ([Matrix44SIMDOperations]) that can be performed on [Float32x4List]
+/// instances.
 library vector_math_operations;
 
 import 'dart:typed_data';


### PR DESCRIPTION
Rename constants back to lowerCase the style guide was changed, they were already lowerCase previously.

I also added top level documentation for the library files. The vector_math.dart file references some classes that aren't available yet, but will come it a PR that adds them soon.