### PR TITLE
Add perspective transform to Matrix4

### DIFF
--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1843,6 +1843,31 @@ class Matrix4 {
     return arg;
   }
 
+/// Transform [arg] of type [Vector3] using the perspective transformation
+/// defined by [this].
+  Vector3 perspectiveTransform(Vector3 arg) {
+    final x_ = (storage[0] * arg.storage[0]) +
+        (storage[4] * arg.storage[1]) +
+        (storage[8] * arg.storage[2]) +
+        storage[12];
+    final y_ = (storage[1] * arg.storage[0]) +
+        (storage[5] * arg.storage[1]) +
+        (storage[9] * arg.storage[2]) +
+        storage[13];
+    final z_ = (storage[2] * arg.storage[0]) +
+        (storage[6] * arg.storage[1]) +
+        (storage[10] * arg.storage[2]) +
+        storage[14];
+    final w_ = (storage[3] * arg.storage[0]) +
+        (storage[7] * arg.storage[1]) +
+        (storage[11] * arg.storage[2]) +
+        storage[15];
+    arg.storage[0] = x_ / w_;
+    arg.storage[1] = y_ / w_;
+    arg.storage[2] = z_ / w_;
+    return arg;
+  }
+
   Vector4 transformed(Vector4 arg, [Vector4 out]) {
     if (out == null) {
       out = new Vector4.copy(arg);

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -1843,6 +1843,31 @@ class Matrix4 {
     return arg;
   }
 
+/// Transform [arg] of type [Vector3] using the perspective transformation
+/// defined by [this].
+  Vector3 perspectiveTransform(Vector3 arg) {
+    final x_ = (storage[0] * arg.storage[0]) +
+        (storage[4] * arg.storage[1]) +
+        (storage[8] * arg.storage[2]) +
+        storage[12];
+    final y_ = (storage[1] * arg.storage[0]) +
+        (storage[5] * arg.storage[1]) +
+        (storage[9] * arg.storage[2]) +
+        storage[13];
+    final z_ = (storage[2] * arg.storage[0]) +
+        (storage[6] * arg.storage[1]) +
+        (storage[10] * arg.storage[2]) +
+        storage[14];
+    final w_ = (storage[3] * arg.storage[0]) +
+        (storage[7] * arg.storage[1]) +
+        (storage[11] * arg.storage[2]) +
+        storage[15];
+    arg.storage[0] = x_ / w_;
+    arg.storage[1] = y_ / w_;
+    arg.storage[2] = z_ / w_;
+    return arg;
+  }
+
   Vector4 transformed(Vector4 arg, [Vector4 out]) {
     if (out == null) {
       out = new Vector4.copy(arg);

--- a/test/matrix_test.dart
+++ b/test/matrix_test.dart
@@ -717,6 +717,15 @@ void testMatrix4Dot() {
   expect(matrix.dotColumn(2, v), equals(110.0));
 }
 
+void testMatrix4PerspectiveTransform() {
+  final matrix = makePerspectiveMatrix(Math.PI, 1.0, 1.0, 100.0);
+  final vec = new Vector3(10.0, 20.0, 30.0);
+
+  matrix.perspectiveTransform(vec);
+
+  relativeTest(vec, new Vector3(0.0, 0.0, 1.087));
+}
+
 void testMatrix2Solving() {
   final Matrix2 A = new Matrix2(2.0, 2.0, 8.0, 20.0);
   final Vector2 b = new Vector2(20.0, 64.0);
@@ -818,6 +827,7 @@ void main() {
   test('Matrix2 dot product', testMatrix2Dot);
   test('Matrix3 dot product', testMatrix3Dot);
   test('Matrix4 dot product', testMatrix4Dot);
+  test('Matrix4 perspective transform', testMatrix4PerspectiveTransform);
 
   test('Matrix2 solving', testMatrix2Solving);
   test('Matrix3 solving', testMatrix3Solving);


### PR DESCRIPTION
A perspective transform is quite a common operation, but at t´most of the time one needs a 3 dimensional vector. At the moment it is required to create a 4 dimensional one with w set to 1, to the transformation, divide by w, that create a 3 dimensional vector again. The new method does everything in one go.