### PR TITLE
Cleanup quaternion

### DIFF
--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -20,309 +20,346 @@
 
 part of vector_math;
 
+/// Defines a [Quaternion] (a four-dimensional vector) for efficient rotation
+/// calculations.
+///
+/// Quaternion are better for interpolating between rotations and avoid the
+/// [gimbal lock](http://de.wikipedia.org/wiki/Gimbal_Lock) problem compared to
+/// euler rotations.
 class Quaternion {
-  final Float32List storage;
+  final Float32List _storage;
 
-  double get x => storage[0];
-  double get y => storage[1];
-  double get z => storage[2];
-  double get w => storage[3];
+  /// Access the internal [storage] of the quaternions components.
+  Float32List get storage => _storage;
+
+  /// Access the [x] component of the quaternion.
+  double get x => _storage[0];
   set x(double x) {
-    storage[0] = x;
+    _storage[0] = x;
   }
+  /// Access the [y] component of the quaternion.
+  double get y => _storage[1];
   set y(double y) {
-    storage[1] = y;
+    _storage[1] = y;
   }
+  /// Access the [z] component of the quaternion.
+  double get z => _storage[2];
   set z(double z) {
-    storage[2] = z;
+    _storage[2] = z;
   }
+  /// Access the [w] component of the quaternion.
+  double get w => _storage[3];
   set w(double w) {
-    storage[3] = w;
+    _storage[3] = w;
   }
 
-  /// Constructs a quaternion using the raw values [x], [y], [z], and [w]
-  Quaternion(double x, double y, double z, double w)
-      : storage = new Float32List(4) {
-    storage[0] = x;
-    storage[1] = y;
-    storage[2] = z;
-    storage[3] = w;
-  }
+  Quaternion._() : _storage = new Float32List(4);
 
-  /// From a rotation matrix [rotationMatrix].
-  Quaternion.fromRotation(Matrix3 rotationMatrix)
-      : storage = new Float32List(4) {
-    double trace = rotationMatrix.trace();
-    if (trace > 0.0) {
-      double s = Math.sqrt(trace + 1.0);
-      storage[3] = s * 0.5;
-      s = 0.5 / s;
-      storage[0] = (rotationMatrix.storage[5] - rotationMatrix.storage[7]) * s;
-      storage[1] = (rotationMatrix.storage[6] - rotationMatrix.storage[2]) * s;
-      storage[2] = (rotationMatrix.storage[1] - rotationMatrix.storage[3]) * s;
-    } else {
-      int i = rotationMatrix.storage[0] < rotationMatrix.storage[4]
-          ? (rotationMatrix.storage[4] < rotationMatrix.storage[8] ? 2 : 1)
-          : (rotationMatrix.storage[0] < rotationMatrix.storage[8] ? 2 : 0);
-      int j = (i + 1) % 3;
-      int k = (i + 2) % 3;
-      double s = Math.sqrt(rotationMatrix.entry(i, i) -
-          rotationMatrix.entry(j, j) -
-          rotationMatrix.entry(k, k) +
-          1.0);
-      storage[i] = s * 0.5;
-      s = 0.5 / s;
-      storage[3] =
-          (rotationMatrix.entry(k, j) - rotationMatrix.entry(j, k)) * s;
-      storage[j] =
-          (rotationMatrix.entry(j, i) + rotationMatrix.entry(i, j)) * s;
-      storage[k] =
-          (rotationMatrix.entry(k, i) + rotationMatrix.entry(i, k)) * s;
-    }
-  }
+  /// Constructs a quaternion using the raw values [x], [y], [z], and [w].
+  factory Quaternion(double x, double y, double z, double w) =>
+      new Quaternion._()..setValues(x, y, z, w);
 
-  /// Rotation of [angle] around [axis].
-  Quaternion.axisAngle(Vector3 axis, double angle)
-      : storage = new Float32List(4) {
-    setAxisAngle(axis, angle);
-  }
+  /// Constructs a quaternion from a rotation matrix [rotationMatrix].
+  factory Quaternion.fromRotation(Matrix3 rotationMatrix) =>
+      new Quaternion._()..setFromRotation(rotationMatrix);
 
-  /// Copies [original].
-  Quaternion.copy(Quaternion original) : storage = new Float32List(4) {
-    storage[0] = original.storage[0];
-    storage[1] = original.storage[1];
-    storage[2] = original.storage[2];
-    storage[3] = original.storage[3];
-  }
+  /// Constructs a quaternion from a rotation of [angle] around [axis].
+  factory Quaternion.axisAngle(Vector3 axis, double angle) =>
+      new Quaternion._()..setAxisAngle(axis, angle);
 
-  /// Random rotation.
-  Quaternion.random(Math.Random rn) : storage = new Float32List(4) {
-    // From: "Uniform Random Rotations", Ken Shoemake, Graphics Gems III,
-    // pg. 124-132.
-    double x0 = rn.nextDouble();
-    double r1 = Math.sqrt(1.0 - x0);
-    double r2 = Math.sqrt(x0);
-    double t1 = Math.PI * 2.0 * rn.nextDouble();
-    double t2 = Math.PI * 2.0 * rn.nextDouble();
-    double c1 = Math.cos(t1);
-    double s1 = Math.sin(t1);
-    double c2 = Math.cos(t2);
-    double s2 = Math.sin(t2);
-    storage[0] = s1 * r1;
-    storage[1] = c1 * r1;
-    storage[2] = s2 * r2;
-    storage[3] = c2 * r2;
-  }
+  /// Constructs a quaternion as a copy of [original].
+  factory Quaternion.copy(Quaternion original) =>
+      new Quaternion._()..setFrom(original);
 
-  /// Constructs the identity quaternion
-  Quaternion.identity() : storage = new Float32List(4) {
-    storage[3] = 1.0;
-  }
+  /// Constructs a quaternion with a random rotation. The random number
+  /// generator [rn] is used to generate the random numbers for the rotation.
+  factory Quaternion.random(Math.Random rn) =>
+      new Quaternion._()..setRandom(rn);
 
-  /// Time derivative of [q] with angular velocity [omega].
-  Quaternion.dq(Quaternion q, Vector3 omega) : storage = new Float32List(4) {
-    double qx = q.storage[0];
-    double qy = q.storage[1];
-    double qz = q.storage[2];
-    double qw = q.storage[3];
-    double ox = omega.storage[0];
-    double oy = omega.storage[1];
-    double oz = omega.storage[2];
-    double _x = ox * qw + oy * qz - oz * qy;
-    double _y = oy * qw + oz * qx - ox * qz;
-    double _z = oz * qw + ox * qy - oy * qx;
-    double _w = -ox * qx - oy * qy - oz * qz;
-    storage[0] = _x * 0.5;
-    storage[1] = _y * 0.5;
-    storage[2] = _z * 0.5;
-    storage[3] = _w * 0.5;
-  }
+  /// Constructs a quaternion set to the identity quaternion.
+  factory Quaternion.identity() => new Quaternion._().._storage[3] = 1.0;
 
-  /// Constructs Quaternion with given Float32List as [storage].
-  Quaternion.fromFloat32List(Float32List this.storage);
+  /// Constructs a quaternion from time derivative of [q] with angular
+  /// velocity [omega].
+  factory Quaternion.dq(Quaternion q, Vector3 omega) =>
+      new Quaternion._()..setDQ(q, omega);
 
-  /// Constructs Quaternion with a [storage] that views given [buffer] starting at [offset].
-  /// [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
+  /// Constructs a quaternion from [yaw], [pitch] and [roll].
+  factory Quaternion.euler(double yaw, double pitch, double roll) =>
+      new Quaternion._()..setEuler(yaw, pitch, roll);
+
+  /// Constructs a quaternion with given Float32List as [storage].
+  Quaternion.fromFloat32List(this._storage);
+
+  /// Constructs a quaternion with a [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float32List.BYTES_PER_ELEMENT].
   Quaternion.fromBuffer(ByteBuffer buffer, int offset)
-      : storage = new Float32List.view(buffer, offset, 4);
+      : _storage = new Float32List.view(buffer, offset, 4);
 
-  /// Returns a new copy of this
-  Quaternion clone() {
-    return new Quaternion.copy(this);
+  /// Returns a new copy of [this].
+  Quaternion clone() => new Quaternion.copy(this);
+
+  /// Copy [source] into [this].
+  void setFrom(Quaternion source) {
+    final sourceStorage = source._storage;
+    _storage[0] = sourceStorage[0];
+    _storage[1] = sourceStorage[1];
+    _storage[2] = sourceStorage[2];
+    _storage[3] = sourceStorage[3];
   }
 
-  /// Copy [source] into [this]
-  void copyFrom(Quaternion source) {
-    storage[0] = source.storage[0];
-    storage[1] = source.storage[1];
-    storage[2] = source.storage[2];
-    storage[3] = source.storage[3];
+  /// Set the quaternion to the raw values [x], [y], [z], and [w].
+  void setValues(double x, double y, double z, double w) {
+    _storage[0] = x;
+    _storage[1] = y;
+    _storage[2] = z;
+    _storage[3] = w;
   }
 
-  /// Copy [this] into [target].
-  void copyTo(Quaternion target) {
-    target.storage[0] = storage[0];
-    target.storage[1] = storage[1];
-    target.storage[2] = storage[2];
-    target.storage[3] = storage[3];
-  }
-
-  /// Set quaternion with rotation of [radians] around [axis].
+  /// Set the quaternion with rotation of [radians] around [axis].
   void setAxisAngle(Vector3 axis, double radians) {
-    double len = axis.length;
+    final len = axis.length;
     if (len == 0.0) {
       return;
     }
-    double halfSin = Math.sin(radians * 0.5) / len;
-    storage[0] = axis.storage[0] * halfSin;
-    storage[1] = axis.storage[1] * halfSin;
-    storage[2] = axis.storage[2] * halfSin;
-    storage[3] = Math.cos(radians * 0.5);
+    final halfSin = Math.sin(radians * 0.5) / len;
+    final axisStorage = axis.storage;
+    _storage[0] = axisStorage[0] * halfSin;
+    _storage[1] = axisStorage[1] * halfSin;
+    _storage[2] = axisStorage[2] * halfSin;
+    _storage[3] = Math.cos(radians * 0.5);
+  }
+
+  /// Set the quaternion with rotation from a rotation matrix [rotationMatrix].
+  void setFromRotation(Matrix3 rotationMatrix) {
+    final rotationMatrixStorage = rotationMatrix.storage;
+    final trace = rotationMatrix.trace();
+    if (trace > 0.0) {
+      var s = Math.sqrt(trace + 1.0);
+      _storage[3] = s * 0.5;
+      s = 0.5 / s;
+      _storage[0] = (rotationMatrixStorage[5] - rotationMatrixStorage[7]) * s;
+      _storage[1] = (rotationMatrixStorage[6] - rotationMatrixStorage[2]) * s;
+      _storage[2] = (rotationMatrixStorage[1] - rotationMatrixStorage[3]) * s;
+    } else {
+      var i = rotationMatrixStorage[0] < rotationMatrixStorage[4]
+          ? (rotationMatrixStorage[4] < rotationMatrixStorage[8] ? 2 : 1)
+          : (rotationMatrixStorage[0] < rotationMatrixStorage[8] ? 2 : 0);
+      var j = (i + 1) % 3;
+      var k = (i + 2) % 3;
+      var s = Math.sqrt(rotationMatrixStorage[rotationMatrix.index(i, i)] -
+          rotationMatrixStorage[rotationMatrix.index(j, j)] -
+          rotationMatrixStorage[rotationMatrix.index(k, k)] +
+          1.0);
+      _storage[i] = s * 0.5;
+      s = 0.5 / s;
+      _storage[3] = (rotationMatrixStorage[rotationMatrix.index(k, j)] -
+              rotationMatrixStorage[rotationMatrix.index(j, k)]) *
+          s;
+      _storage[j] = (rotationMatrixStorage[rotationMatrix.index(j, i)] +
+              rotationMatrixStorage[rotationMatrix.index(i, j)]) *
+          s;
+      _storage[k] = (rotationMatrixStorage[rotationMatrix.index(k, i)] +
+              rotationMatrixStorage[rotationMatrix.index(i, k)]) *
+          s;
+    }
+  }
+
+  /// Set the quaternion to a random rotation. The random number generator [rn]
+  /// is used to generate the random numbers for the rotation.
+  void setRandom(Math.Random rn) {
+    // From: "Uniform Random Rotations", Ken Shoemake, Graphics Gems III,
+    // pg. 124-132.
+    final x0 = rn.nextDouble();
+    final r1 = Math.sqrt(1.0 - x0);
+    final r2 = Math.sqrt(x0);
+    final t1 = Math.PI * 2.0 * rn.nextDouble();
+    final t2 = Math.PI * 2.0 * rn.nextDouble();
+    final c1 = Math.cos(t1);
+    final s1 = Math.sin(t1);
+    final c2 = Math.cos(t2);
+    final s2 = Math.sin(t2);
+    _storage[0] = s1 * r1;
+    _storage[1] = c1 * r1;
+    _storage[2] = s2 * r2;
+    _storage[3] = c2 * r2;
+  }
+
+  /// Set the quaternion to the time derivative of [q] with angular velocity
+  /// [omega].
+  void setDQ(Quaternion q, Vector3 omega) {
+    final qStorage = q._storage;
+    final omegaStorage = omega.storage;
+    final qx = qStorage[0];
+    final qy = qStorage[1];
+    final qz = qStorage[2];
+    final qw = qStorage[3];
+    final ox = omegaStorage[0];
+    final oy = omegaStorage[1];
+    final oz = omegaStorage[2];
+    final _x = ox * qw + oy * qz - oz * qy;
+    final _y = oy * qw + oz * qx - ox * qz;
+    final _z = oz * qw + ox * qy - oy * qx;
+    final _w = -ox * qx - oy * qy - oz * qz;
+    _storage[0] = _x * 0.5;
+    _storage[1] = _y * 0.5;
+    _storage[2] = _z * 0.5;
+    _storage[3] = _w * 0.5;
   }
 
   /// Set quaternion with rotation of [yaw], [pitch] and [roll].
   void setEuler(double yaw, double pitch, double roll) {
-    double halfYaw = yaw * 0.5;
-    double halfPitch = pitch * 0.5;
-    double halfRoll = roll * 0.5;
-    double cosYaw = Math.cos(halfYaw);
-    double sinYaw = Math.sin(halfYaw);
-    double cosPitch = Math.cos(halfPitch);
-    double sinPitch = Math.sin(halfPitch);
-    double cosRoll = Math.cos(halfRoll);
-    double sinRoll = Math.sin(halfRoll);
-    storage[0] = cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw;
-    storage[1] = cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw;
-    storage[2] = sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw;
-    storage[3] = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
+    final halfYaw = yaw * 0.5;
+    final halfPitch = pitch * 0.5;
+    final halfRoll = roll * 0.5;
+    final cosYaw = Math.cos(halfYaw);
+    final sinYaw = Math.sin(halfYaw);
+    final cosPitch = Math.cos(halfPitch);
+    final sinPitch = Math.sin(halfPitch);
+    final cosRoll = Math.cos(halfRoll);
+    final sinRoll = Math.sin(halfRoll);
+    _storage[0] = cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw;
+    _storage[1] = cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw;
+    _storage[2] = sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw;
+    _storage[3] = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
   }
 
   /// Normalize [this].
   Quaternion normalize() {
-    double l = length;
+    var l = length;
     if (l == 0.0) {
       return this;
     }
     l = 1.0 / l;
-    storage[3] = storage[3] * l;
-    storage[2] = storage[2] * l;
-    storage[1] = storage[1] * l;
-    storage[0] = storage[0] * l;
+    _storage[3] = _storage[3] * l;
+    _storage[2] = _storage[2] * l;
+    _storage[1] = _storage[1] * l;
+    _storage[0] = _storage[0] * l;
     return this;
   }
 
   /// Conjugate [this].
   Quaternion conjugate() {
-    storage[2] = -storage[2];
-    storage[1] = -storage[1];
-    storage[0] = -storage[0];
+    _storage[2] = -_storage[2];
+    _storage[1] = -_storage[1];
+    _storage[0] = -_storage[0];
     return this;
   }
 
   /// Invert [this].
   Quaternion inverse() {
-    double l = 1.0 / length2;
-    storage[3] = storage[3] * l;
-    storage[2] = -storage[2] * l;
-    storage[1] = -storage[1] * l;
-    storage[0] = -storage[0] * l;
+    final l = 1.0 / length2;
+    _storage[3] = _storage[3] * l;
+    _storage[2] = -_storage[2] * l;
+    _storage[1] = -_storage[1] * l;
+    _storage[0] = -_storage[0] * l;
     return this;
   }
 
   /// Normalized copy of [this].
-  Quaternion normalized() {
-    return new Quaternion.copy(this).normalize();
-  }
+  Quaternion normalized() => clone()..normalize();
 
   /// Conjugated copy of [this].
-  Quaternion conjugated() {
-    return new Quaternion.copy(this).conjugate();
-  }
+  Quaternion conjugated() => clone()..conjugate();
 
   /// Inverted copy of [this].
-  Quaternion inverted() {
-    return new Quaternion.copy(this).inverse();
-  }
+  Quaternion inverted() => clone()..inverse();
 
-  /// Radians of rotation.
-  double get radians => 2.0 * Math.acos(storage[3]);
+  /// [radians] of rotation around the [axis] of the rotation.
+  double get radians => 2.0 * Math.acos(_storage[3]);
 
-  /// Axis of rotation.
+  /// [axis] of rotation.
   Vector3 get axis {
-    double scale = 1.0 / (1.0 - (storage[3] * storage[3]));
+    final scale = 1.0 / (1.0 - (_storage[3] * _storage[3]));
     return new Vector3(
-        storage[0] * scale, storage[1] * scale, storage[2] * scale);
+        _storage[0] * scale, _storage[1] * scale, _storage[2] * scale);
   }
 
   /// Length squared.
   double get length2 {
-    double _x = storage[0];
-    double _y = storage[1];
-    double _z = storage[2];
-    double _w = storage[3];
-    return (_x * _x) + (_y * _y) + (_z * _z) + (_w * _w);
+    final x = _storage[0];
+    final y = _storage[1];
+    final z = _storage[2];
+    final w = _storage[3];
+    return (x * x) + (y * y) + (z * z) + (w * w);
   }
 
   /// Length.
-  double get length {
-    return Math.sqrt(length2);
-  }
+  double get length => Math.sqrt(length2);
 
   /// Returns a copy of [v] rotated by quaternion.
   Vector3 rotated(Vector3 v) {
-    Vector3 out = new Vector3.copy(v);
-    return rotate(out);
+    final out = v.clone();
+    rotate(out);
+    return out;
   }
 
   /// Rotates [v] by [this].
   Vector3 rotate(Vector3 v) {
     // conjugate(this) * [v,0] * this
-    double _w = storage[3];
-    double _z = storage[2];
-    double _y = storage[1];
-    double _x = storage[0];
-    double tiw = _w;
-    double tiz = -_z;
-    double tiy = -_y;
-    double tix = -_x;
-    double tx = tiw * v.x + tix * 0.0 + tiy * v.z - tiz * v.y;
-    double ty = tiw * v.y + tiy * 0.0 + tiz * v.x - tix * v.z;
-    double tz = tiw * v.z + tiz * 0.0 + tix * v.y - tiy * v.x;
-    double tw = tiw * 0.0 - tix * v.x - tiy * v.y - tiz * v.z;
-    double result_x = tw * _x + tx * _w + ty * _z - tz * _y;
-    double result_y = tw * _y + ty * _w + tz * _x - tx * _z;
-    double result_z = tw * _z + tz * _w + tx * _y - ty * _x;
-    v.storage[2] = result_z;
-    v.storage[1] = result_y;
-    v.storage[0] = result_x;
+    final _w = _storage[3];
+    final _z = _storage[2];
+    final _y = _storage[1];
+    final _x = _storage[0];
+    final tiw = _w;
+    final tiz = -_z;
+    final tiy = -_y;
+    final tix = -_x;
+    final tx = tiw * v.x + tix * 0.0 + tiy * v.z - tiz * v.y;
+    final ty = tiw * v.y + tiy * 0.0 + tiz * v.x - tix * v.z;
+    final tz = tiw * v.z + tiz * 0.0 + tix * v.y - tiy * v.x;
+    final tw = tiw * 0.0 - tix * v.x - tiy * v.y - tiz * v.z;
+    final result_x = tw * _x + tx * _w + ty * _z - tz * _y;
+    final result_y = tw * _y + ty * _w + tz * _x - tx * _z;
+    final result_z = tw * _z + tz * _w + tx * _y - ty * _x;
+    final vStorage = v.storage;
+    vStorage[2] = result_z;
+    vStorage[1] = result_y;
+    vStorage[0] = result_x;
     return v;
   }
 
+  /// Add [arg] to [this].
+  void add(Quaternion arg) {
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0];
+    _storage[1] = _storage[1] + argStorage[1];
+    _storage[2] = _storage[2] + argStorage[2];
+    _storage[3] = _storage[3] + argStorage[3];
+  }
+
+  /// Subtracts [arg] from [this].
+  void sub(Quaternion arg) {
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] - argStorage[0];
+    _storage[1] = _storage[1] - argStorage[1];
+    _storage[2] = _storage[2] - argStorage[2];
+    _storage[3] = _storage[3] - argStorage[3];
+  }
+
   /// Scales [this] by [scale].
-  Quaternion scale(double scale) {
-    storage[3] = storage[3] * scale;
-    storage[2] = storage[2] * scale;
-    storage[1] = storage[1] * scale;
-    storage[0] = storage[0] * scale;
-    return this;
+  void scale(double scale) {
+    _storage[3] = _storage[3] * scale;
+    _storage[2] = _storage[2] * scale;
+    _storage[1] = _storage[1] * scale;
+    _storage[0] = _storage[0] * scale;
   }
 
   /// Scaled copy of [this].
-  Quaternion scaled(double scale) {
-    Quaternion q = new Quaternion.copy(this);
-    return q.scale(scale);
-  }
+  Quaternion scaled(double scale) => clone()..scale(scale);
 
   /// [this] rotated by [other].
   Quaternion operator *(Quaternion other) {
-    double _w = storage[3];
-    double _z = storage[2];
-    double _y = storage[1];
-    double _x = storage[0];
-    double ow = other.storage[3];
-    double oz = other.storage[2];
-    double oy = other.storage[1];
-    double ox = other.storage[0];
+    double _w = _storage[3];
+    double _z = _storage[2];
+    double _y = _storage[1];
+    double _x = _storage[0];
+    final otherStorage = other._storage;
+    double ow = otherStorage[3];
+    double oz = otherStorage[2];
+    double oy = otherStorage[1];
+    double ox = otherStorage[0];
     return new Quaternion(_w * ox + _x * ow + _y * oz - _z * oy,
         _w * oy + _y * ow + _z * ox - _x * oz, _w * oz +
             _z * ow +
@@ -331,80 +368,83 @@ class Quaternion {
   }
 
   /// Returns copy of [this] + [other].
-  Quaternion operator +(Quaternion other) {
-    return new Quaternion(storage[0] + other.storage[0],
-        storage[1] + other.storage[1], storage[2] + other.storage[2],
-        storage[3] + other.storage[3]);
-  }
+  Quaternion operator +(Quaternion other) => clone()..add(other);
 
   /// Returns copy of [this] - [other].
-  Quaternion operator -(Quaternion other) {
-    return new Quaternion(storage[0] - other.storage[0],
-        storage[1] - other.storage[1], storage[2] - other.storage[2],
-        storage[3] - other.storage[3]);
-  }
+  Quaternion operator -(Quaternion other) => clone()..sub(other);
 
   /// Returns negated copy of [this].
-  Quaternion operator -() {
-    return new Quaternion(-storage[0], -storage[1], -storage[2], -storage[3]);
-  }
+  Quaternion operator -() => conjugated();
 
-  double operator [](int i) => storage[i];
+  /// Access the component of the quaternion at the index [i].
+  double operator [](int i) => _storage[i];
 
+  /// Set the component of the quaternion at the index [i].
   void operator []=(int i, double arg) {
-    storage[i] = arg;
+    _storage[i] = arg;
   }
 
   /// Returns a rotation matrix containing the same rotation as [this].
-  Matrix3 asRotationMatrix() {
-    double d = length2;
+  Matrix3 asRotationMatrix() => copyRotationInto(new Matrix3.zero());
+
+  /// Set [rotationMatrix] to a rotation matrix containing the same rotation as
+  /// [this].
+  Matrix3 copyRotationInto(Matrix3 rotationMatrix) {
+    final d = length2;
     assert(d != 0.0);
-    double s = 2.0 / d;
+    final s = 2.0 / d;
 
-    double _x = storage[0];
-    double _y = storage[1];
-    double _z = storage[2];
-    double _w = storage[3];
+    final _x = _storage[0];
+    final _y = _storage[1];
+    final _z = _storage[2];
+    final _w = _storage[3];
 
-    double xs = _x * s;
-    double ys = _y * s;
-    double zs = _z * s;
+    final xs = _x * s;
+    final ys = _y * s;
+    final zs = _z * s;
 
-    double wx = _w * xs;
-    double wy = _w * ys;
-    double wz = _w * zs;
+    final wx = _w * xs;
+    final wy = _w * ys;
+    final wz = _w * zs;
 
-    double xx = _x * xs;
-    double xy = _x * ys;
-    double xz = _x * zs;
+    final xx = _x * xs;
+    final xy = _x * ys;
+    final xz = _x * zs;
 
-    double yy = _y * ys;
-    double yz = _y * zs;
-    double zz = _z * zs;
+    final yy = _y * ys;
+    final yz = _y * zs;
+    final zz = _z * zs;
 
-    return new Matrix3(1.0 - (yy + zz), xy + wz, xz - wy, // column 0
-        xy - wz, 1.0 - (xx + zz), yz + wx, // column 1
-        xz + wy, yz - wx, 1.0 - (xx + yy)); // column 2
+    final rotationMatrixStorage = rotationMatrix.storage;
+    rotationMatrixStorage[0] = 1.0 - (yy + zz); // column 0
+    rotationMatrixStorage[1] = xy + wz;
+    rotationMatrixStorage[2] = xz - wy;
+    rotationMatrixStorage[3] = xy - wz; // column 1
+    rotationMatrixStorage[4] = 1.0 - (xx + zz);
+    rotationMatrixStorage[5] = yz + wx;
+    rotationMatrixStorage[6] = xz + wy; // column 2
+    rotationMatrixStorage[7] = yz - wx;
+    rotationMatrixStorage[8] = 1.0 - (xx + yy);
+    return rotationMatrix;
   }
 
   /// Printable string.
-  String toString() {
-    return '${storage[0]}, ${storage[1]}, ${storage[2]} @ ${storage[3]}';
-  }
+  String toString() => '${_storage[0]}, ${_storage[1]},'
+      ' ${_storage[2]} @ ${_storage[3]}';
 
   /// Relative error between [this] and [correct].
   double relativeError(Quaternion correct) {
-    Quaternion diff = correct - this;
-    double norm_diff = diff.length;
-    double correct_norm = correct.length;
+    final diff = correct - this;
+    final norm_diff = diff.length;
+    final correct_norm = correct.length;
     return norm_diff / correct_norm;
   }
 
   /// Absolute error between [this] and [correct].
   double absoluteError(Quaternion correct) {
-    double this_norm = length;
-    double correct_norm = correct.length;
-    double norm_diff = (this_norm - correct_norm).abs();
+    final this_norm = length;
+    final correct_norm = correct.length;
+    final norm_diff = (this_norm - correct_norm).abs();
     return norm_diff;
   }
 }


### PR DESCRIPTION
* Make storage private.
* Replace most constructors by factory constructors that use the set* method with the same behavior. This allows users of the class to reuse existing instances.
* Inline storages of arguments passed into methods to allow more optimizations by dart2js.