### PR TITLE
Cleanup ray class

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import 'package:vector_math/vector_math.dart';
 
 ## Documentation
 
-Read the [docs](www.dartdocs.org/documentation/vector_math/latest/index.html#vector_math)
+Read the [docs](http://www.dartdocs.org/documentation/vector_math/latest/index.html#vector_math)
 
 ## Examples
 

--- a/lib/src/vector_math/ray.dart
+++ b/lib/src/vector_math/ray.dart
@@ -4,51 +4,56 @@
 
 part of vector_math;
 
+/// Defines a [Ray] by an [origin] and a [direction].
 class Ray {
   final Vector3 _origin;
   final Vector3 _direction;
 
+  /// The [origin] of the ray.
   Vector3 get origin => _origin;
+  /// The [direction] of the ray.
   Vector3 get direction => _direction;
 
+  /// Create a new, uninitialized ray.
   Ray()
       : _origin = new Vector3.zero(),
         _direction = new Vector3.zero();
 
+  /// Create a ray as a copy of [other].
   Ray.copy(Ray other)
       : _origin = new Vector3.copy(other._origin),
         _direction = new Vector3.copy(other._direction);
 
-  Ray.originDirection(Vector3 origin_, Vector3 direction_)
-      : _origin = new Vector3.copy(origin_),
-        _direction = new Vector3.copy(direction_);
+  /// Create a ray with an [origin] and a [direction].
+  Ray.originDirection(Vector3 origin, Vector3 direction)
+      : _origin = new Vector3.copy(origin),
+        _direction = new Vector3.copy(direction);
 
-  void copyOriginDirection(Vector3 origin_, Vector3 direction_) {
-    origin_.setFrom(_origin);
-    direction_.setFrom(_direction);
-  }
-
-  void copyFrom(Ray o) {
-    _origin.setFrom(o._origin);
-    _direction.setFrom(o._direction);
-  }
-
-  void copyInto(Ray o) {
-    o._origin.setFrom(_origin);
-    o._direction.setFrom(_direction);
+  /// Copy the [origin] and [direction] from [other] into [this].
+  void copyFrom(Ray other) {
+    _origin.setFrom(other._origin);
+    _direction.setFrom(other._direction);
   }
 
   /// Returns the position on [this] with a distance of [t] from [origin].
-  Vector3 at(double t) {
-    return _direction.scaled(t).add(_origin);
+  Vector3 at(double t) => _direction.scaled(t)..add(_origin);
+
+  /// Copy the position on [this] with a distance of [t] from [origin] into
+  /// [other].
+  void copyAt(Vector3 other, double t) {
+    other
+      ..setFrom(_direction)
+      ..scale(t)
+      ..add(_origin);
   }
 
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
   double intersectsWithSphere(Sphere other) {
-    final r2 = other.radius * other.radius;
-    final l = other.center.clone().sub(origin);
-    final s = l.dot(direction);
+    final r = other._radius;
+    final r2 = r * r;
+    final l = other._center.clone()..sub(_origin);
+    final s = l.dot(_direction);
     final l2 = l.dot(l);
     if (s < 0 && l2 > r2) {
       return null;
@@ -62,73 +67,169 @@ class Ray {
     return (l2 > r2) ? s - q : s + q;
   }
 
+  // Some varaibles that are used for intersectsWithTriangle and
+  // intersectsWithQuad. The performance is better in Dart and JS if we avoid
+  // to create temporary instance over and over. Also reduce GC.
+  static final _e1 = new Vector3.zero();
+  static final _e2 = new Vector3.zero();
+  static final _q = new Vector3.zero();
+  static final _s = new Vector3.zero();
+  static final _r = new Vector3.zero();
+
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
   double intersectsWithTriangle(Triangle other) {
     const double EPSILON = 10e-6;
 
-    final e1 = other.point1.clone().sub(other.point0);
-    final e2 = other.point2.clone().sub(other.point0);
+    final point0 = other._point0;
+    final point1 = other._point1;
+    final point2 = other._point2;
 
-    final q = direction.cross(e2);
-    final a = e1.dot(q);
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a = _e1.dot(_q);
 
     if (a > -EPSILON && a < EPSILON) {
       return null;
     }
 
     final f = 1 / a;
-    final s = origin.clone().sub(other.point0);
-    final u = f * (s.dot(q));
+    _s
+      ..setFrom(_origin)
+      ..sub(point0);
+    final u = f * (_s.dot(_q));
 
     if (u < 0.0) {
       return null;
     }
 
-    final r = s.cross(e1);
-    final v = f * (direction.dot(r));
+    _s.crossInto(_e1, _r);
+    final v = f * (_direction.dot(_r));
 
     if (v < -EPSILON || u + v > 1.0 + EPSILON) {
       return null;
     }
 
-    final t = f * (e2.dot(r));
+    final t = f * (_e2.dot(_r));
 
     return t;
   }
 
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
-  double intersectsWithAabb3(Aabb3 other) {
-    Vector3 t1 = new Vector3.zero(),
-        t2 = new Vector3.zero();
-    double tNear = -double.MAX_FINITE;
-    double tFar = double.MAX_FINITE;
+  double intersectsWithQuad(Quad other) {
+    const double EPSILON = 10e-6;
 
-    for (int i = 0; i < 3; ++i) {
-      if (direction[i] == 0.0) {
-        if ((origin[i] < other.min[i]) || (origin[i] > other.max[i])) {
+    // First triangle
+    var point0 = other._point0;
+    var point1 = other._point1;
+    var point2 = other._point2;
+
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a0 = _e1.dot(_q);
+
+    if (!(a0 > -EPSILON && a0 < EPSILON)) {
+      final f = 1 / a0;
+      _s
+        ..setFrom(_origin)
+        ..sub(point0);
+      final u = f * (_s.dot(_q));
+
+      if (u >= 0.0) {
+        _s.crossInto(_e1, _r);
+        final v = f * (_direction.dot(_r));
+
+        if (!(v < -EPSILON || u + v > 1.0 + EPSILON)) {
+          final t = f * (_e2.dot(_r));
+
+          return t;
+        }
+      }
+    }
+
+    // Second triangle
+    point0 = other._point3;
+    point1 = other._point0;
+    point2 = other._point2;
+
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a1 = _e1.dot(_q);
+
+    if (!(a1 > -EPSILON && a1 < EPSILON)) {
+      final f = 1 / a1;
+      _s
+        ..setFrom(_origin)
+        ..sub(point0);
+      final u = f * (_s.dot(_q));
+
+      if (u >= 0.0) {
+        _s.crossInto(_e1, _r);
+        final v = f * (_direction.dot(_r));
+
+        if (!(v < -EPSILON || u + v > 1.0 + EPSILON)) {
+          final t = f * (_e2.dot(_r));
+
+          return t;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /// Return the distance from the origin of [this] to the intersection with
+  /// [other] if [this] intersects with [other], or null if the don't intersect.
+  double intersectsWithAabb3(Aabb3 other) {
+    final otherMin = other.min;
+    final otherMax = other.max;
+
+    var tNear = -double.MAX_FINITE;
+    var tFar = double.MAX_FINITE;
+
+    for (var i = 0; i < 3; ++i) {
+      if (_direction[i] == 0.0) {
+        if (_origin[i] < otherMin[i] || _origin[i] > otherMax[i]) {
           return null;
         }
       } else {
-        t1[i] = (other.min[i] - origin[i]) / direction[i];
-        t2[i] = (other.max[i] - origin[i]) / direction[i];
+        var t1 = (otherMin[i] - _origin[i]) / _direction[i];
+        var t2 = (otherMax[i] - _origin[i]) / _direction[i];
 
-        if (t1[i] > t2[i]) {
+        if (t1 > t2) {
           final temp = t1;
           t1 = t2;
           t2 = temp;
         }
 
-        if (t1[i] > tNear) {
-          tNear = t1[i];
+        if (t1 > tNear) {
+          tNear = t1;
         }
 
-        if (t2[i] < tFar) {
-          tFar = t2[i];
+        if (t2 < tFar) {
+          tFar = t2;
         }
 
-        if ((tNear > tFar) || (tFar < 0)) {
+        if (tNear > tFar || tFar < 0) {
           return null;
         }
       }

--- a/lib/src/vector_math_64/quad.dart
+++ b/lib/src/vector_math_64/quad.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 part of vector_math_64;
 
 /// Defines a quad by four points.

--- a/lib/src/vector_math_64/ray.dart
+++ b/lib/src/vector_math_64/ray.dart
@@ -4,51 +4,56 @@
 
 part of vector_math_64;
 
+/// Defines a [Ray] by an [origin] and a [direction].
 class Ray {
   final Vector3 _origin;
   final Vector3 _direction;
 
+  /// The [origin] of the ray.
   Vector3 get origin => _origin;
+  /// The [direction] of the ray.
   Vector3 get direction => _direction;
 
+  /// Create a new, uninitialized ray.
   Ray()
       : _origin = new Vector3.zero(),
         _direction = new Vector3.zero();
 
+  /// Create a ray as a copy of [other].
   Ray.copy(Ray other)
       : _origin = new Vector3.copy(other._origin),
         _direction = new Vector3.copy(other._direction);
 
-  Ray.originDirection(Vector3 origin_, Vector3 direction_)
-      : _origin = new Vector3.copy(origin_),
-        _direction = new Vector3.copy(direction_);
+  /// Create a ray with an [origin] and a [direction].
+  Ray.originDirection(Vector3 origin, Vector3 direction)
+      : _origin = new Vector3.copy(origin),
+        _direction = new Vector3.copy(direction);
 
-  void copyOriginDirection(Vector3 origin_, Vector3 direction_) {
-    origin_.setFrom(_origin);
-    direction_.setFrom(_direction);
-  }
-
-  void copyFrom(Ray o) {
-    _origin.setFrom(o._origin);
-    _direction.setFrom(o._direction);
-  }
-
-  void copyInto(Ray o) {
-    o._origin.setFrom(_origin);
-    o._direction.setFrom(_direction);
+  /// Copy the [origin] and [direction] from [other] into [this].
+  void copyFrom(Ray other) {
+    _origin.setFrom(other._origin);
+    _direction.setFrom(other._direction);
   }
 
   /// Returns the position on [this] with a distance of [t] from [origin].
-  Vector3 at(double t) {
-    return _direction.scaled(t).add(_origin);
+  Vector3 at(double t) => _direction.scaled(t)..add(_origin);
+
+  /// Copy the position on [this] with a distance of [t] from [origin] into
+  /// [other].
+  void copyAt(Vector3 other, double t) {
+    other
+      ..setFrom(_direction)
+      ..scale(t)
+      ..add(_origin);
   }
 
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
   double intersectsWithSphere(Sphere other) {
-    final r2 = other.radius * other.radius;
-    final l = other.center.clone().sub(origin);
-    final s = l.dot(direction);
+    final r = other._radius;
+    final r2 = r * r;
+    final l = other._center.clone()..sub(_origin);
+    final s = l.dot(_direction);
     final l2 = l.dot(l);
     if (s < 0 && l2 > r2) {
       return null;
@@ -62,73 +67,169 @@ class Ray {
     return (l2 > r2) ? s - q : s + q;
   }
 
+  // Some varaibles that are used for intersectsWithTriangle and
+  // intersectsWithQuad. The performance is better in Dart and JS if we avoid
+  // to create temporary instance over and over. Also reduce GC.
+  static final _e1 = new Vector3.zero();
+  static final _e2 = new Vector3.zero();
+  static final _q = new Vector3.zero();
+  static final _s = new Vector3.zero();
+  static final _r = new Vector3.zero();
+
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
   double intersectsWithTriangle(Triangle other) {
     const double EPSILON = 10e-6;
 
-    final e1 = other.point1.clone().sub(other.point0);
-    final e2 = other.point2.clone().sub(other.point0);
+    final point0 = other._point0;
+    final point1 = other._point1;
+    final point2 = other._point2;
 
-    final q = direction.cross(e2);
-    final a = e1.dot(q);
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a = _e1.dot(_q);
 
     if (a > -EPSILON && a < EPSILON) {
       return null;
     }
 
     final f = 1 / a;
-    final s = origin.clone().sub(other.point0);
-    final u = f * (s.dot(q));
+    _s
+      ..setFrom(_origin)
+      ..sub(point0);
+    final u = f * (_s.dot(_q));
 
     if (u < 0.0) {
       return null;
     }
 
-    final r = s.cross(e1);
-    final v = f * (direction.dot(r));
+    _s.crossInto(_e1, _r);
+    final v = f * (_direction.dot(_r));
 
     if (v < -EPSILON || u + v > 1.0 + EPSILON) {
       return null;
     }
 
-    final t = f * (e2.dot(r));
+    final t = f * (_e2.dot(_r));
 
     return t;
   }
 
   /// Return the distance from the origin of [this] to the intersection with
   /// [other] if [this] intersects with [other], or null if the don't intersect.
-  double intersectsWithAabb3(Aabb3 other) {
-    Vector3 t1 = new Vector3.zero(),
-        t2 = new Vector3.zero();
-    double tNear = -double.MAX_FINITE;
-    double tFar = double.MAX_FINITE;
+  double intersectsWithQuad(Quad other) {
+    const double EPSILON = 10e-6;
 
-    for (int i = 0; i < 3; ++i) {
-      if (direction[i] == 0.0) {
-        if ((origin[i] < other.min[i]) || (origin[i] > other.max[i])) {
+    // First triangle
+    var point0 = other._point0;
+    var point1 = other._point1;
+    var point2 = other._point2;
+
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a0 = _e1.dot(_q);
+
+    if (!(a0 > -EPSILON && a0 < EPSILON)) {
+      final f = 1 / a0;
+      _s
+        ..setFrom(_origin)
+        ..sub(point0);
+      final u = f * (_s.dot(_q));
+
+      if (u >= 0.0) {
+        _s.crossInto(_e1, _r);
+        final v = f * (_direction.dot(_r));
+
+        if (!(v < -EPSILON || u + v > 1.0 + EPSILON)) {
+          final t = f * (_e2.dot(_r));
+
+          return t;
+        }
+      }
+    }
+
+    // Second triangle
+    point0 = other._point3;
+    point1 = other._point0;
+    point2 = other._point2;
+
+    _e1
+      ..setFrom(point1)
+      ..sub(point0);
+    _e2
+      ..setFrom(point2)
+      ..sub(point0);
+
+    _direction.crossInto(_e2, _q);
+    final a1 = _e1.dot(_q);
+
+    if (!(a1 > -EPSILON && a1 < EPSILON)) {
+      final f = 1 / a1;
+      _s
+        ..setFrom(_origin)
+        ..sub(point0);
+      final u = f * (_s.dot(_q));
+
+      if (u >= 0.0) {
+        _s.crossInto(_e1, _r);
+        final v = f * (_direction.dot(_r));
+
+        if (!(v < -EPSILON || u + v > 1.0 + EPSILON)) {
+          final t = f * (_e2.dot(_r));
+
+          return t;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /// Return the distance from the origin of [this] to the intersection with
+  /// [other] if [this] intersects with [other], or null if the don't intersect.
+  double intersectsWithAabb3(Aabb3 other) {
+    final otherMin = other.min;
+    final otherMax = other.max;
+
+    var tNear = -double.MAX_FINITE;
+    var tFar = double.MAX_FINITE;
+
+    for (var i = 0; i < 3; ++i) {
+      if (_direction[i] == 0.0) {
+        if (_origin[i] < otherMin[i] || _origin[i] > otherMax[i]) {
           return null;
         }
       } else {
-        t1[i] = (other.min[i] - origin[i]) / direction[i];
-        t2[i] = (other.max[i] - origin[i]) / direction[i];
+        var t1 = (otherMin[i] - _origin[i]) / _direction[i];
+        var t2 = (otherMax[i] - _origin[i]) / _direction[i];
 
-        if (t1[i] > t2[i]) {
+        if (t1 > t2) {
           final temp = t1;
           t1 = t2;
           t2 = temp;
         }
 
-        if (t1[i] > tNear) {
-          tNear = t1[i];
+        if (t1 > tNear) {
+          tNear = t1;
         }
 
-        if (t2[i] < tFar) {
-          tFar = t2[i];
+        if (t2 < tFar) {
+          tFar = t2;
         }
 
-        if ((tNear > tFar) || (tFar < 0)) {
+        if (tNear > tFar || tFar < 0) {
           return null;
         }
       }

--- a/test/ray_test.dart
+++ b/test/ray_test.dart
@@ -12,13 +12,30 @@ import 'package:vector_math/vector_math.dart';
 
 import 'test_utils.dart';
 
-void testRayAt() {
-  final Ray parent =
-      new Ray.originDirection(v3(1.0, 1.0, 1.0), v3(-1.0, 1.0, 1.0));
+void testAt() {
+  final parent = new Ray.originDirection(_v(1.0, 1.0, 1.0), _v(-1.0, 1.0, 1.0));
 
-  final Vector3 atOrigin = parent.at(0.0);
-  final Vector3 atPositive = parent.at(1.0);
-  final Vector3 atNegative = parent.at(-2.0);
+  final atOrigin = parent.at(0.0);
+  final atPositive = parent.at(1.0);
+  final atNegative = parent.at(-2.0);
+
+  expect(atOrigin.x, equals(1.0));
+  expect(atOrigin.y, equals(1.0));
+  expect(atOrigin.z, equals(1.0));
+  expect(atPositive.x, equals(0.0));
+  expect(atPositive.y, equals(2.0));
+  expect(atPositive.z, equals(2.0));
+  expect(atNegative.x, equals(3.0));
+  expect(atNegative.y, equals(-1.0));
+  expect(atNegative.z, equals(-1.0));
+
+  atOrigin.setZero();
+  atPositive.setZero();
+  atNegative.setZero();
+
+  parent.copyAt(atOrigin, 0.0);
+  parent.copyAt(atPositive, 1.0);
+  parent.copyAt(atNegative, -2.0);
 
   expect(atOrigin.x, equals(1.0));
   expect(atOrigin.y, equals(1.0));
@@ -31,14 +48,13 @@ void testRayAt() {
   expect(atNegative.z, equals(-1.0));
 }
 
-void testRayIntersectionSphere() {
-  final Ray parent =
-      new Ray.originDirection(v3(1.0, 1.0, 1.0), v3(0.0, 1.0, 0.0));
-  final Sphere inside = new Sphere.centerRadius(v3(2.0, 1.0, 1.0), 2.0);
-  final Sphere hitting = new Sphere.centerRadius(v3(2.5, 4.5, 1.0), 2.0);
-  final Sphere cutting = new Sphere.centerRadius(v3(0.0, 5.0, 1.0), 1.0);
-  final Sphere outside = new Sphere.centerRadius(v3(-2.5, 1.0, 1.0), 1.0);
-  final Sphere behind = new Sphere.centerRadius(v3(1.0, -1.0, 1.0), 1.0);
+void testIntersectionSphere() {
+  final parent = new Ray.originDirection(_v(1.0, 1.0, 1.0), _v(0.0, 1.0, 0.0));
+  final inside = new Sphere.centerRadius(_v(2.0, 1.0, 1.0), 2.0);
+  final hitting = new Sphere.centerRadius(_v(2.5, 4.5, 1.0), 2.0);
+  final cutting = new Sphere.centerRadius(_v(0.0, 5.0, 1.0), 1.0);
+  final outside = new Sphere.centerRadius(_v(-2.5, 1.0, 1.0), 1.0);
+  final behind = new Sphere.centerRadius(_v(1.0, -1.0, 1.0), 1.0);
 
   expect(parent.intersectsWithSphere(inside), equals(Math.sqrt(3.0)));
   expect(parent.intersectsWithSphere(hitting), equals(3.5 - Math.sqrt(1.75)));
@@ -47,53 +63,53 @@ void testRayIntersectionSphere() {
   expect(parent.intersectsWithSphere(behind), equals(null));
 }
 
-void testRayIntersectionTriangle() {
-  final Ray parent =
-      new Ray.originDirection(v3(1.0, 1.0, 1.0), v3(0.0, 1.0, 0.0));
-  final Triangle hitting = new Triangle.points(
-      v3(2.0, 2.0, 0.0), v3(0.0, 4.0, -1.0), v3(0.0, 4.0, 3.0));
-  final Triangle cutting = new Triangle.points(
-      v3(0.0, 1.5, 1.0), v3(2.0, 1.5, 1.0), v3(1.0, 1.5, 3.0));
-  final Triangle outside = new Triangle.points(
-      v3(2.0, 2.0, 0.0), v3(2.0, 6.0, 0.0), v3(2.0, 2.0, 3.0));
-  final Triangle behind = new Triangle.points(
-      v3(0.0, 0.0, 0.0), v3(0.0, 3.0, 0.0), v3(0.0, 3.0, 4.0));
+void testIntersectionTriangle() {
+  final parent = new Ray.originDirection(_v(1.0, 1.0, 1.0), _v(0.0, 1.0, 0.0));
+  final hitting = new Triangle.points(
+      _v(2.0, 2.0, 0.0), _v(0.0, 4.0, -1.0), _v(0.0, 4.0, 3.0));
+  final cutting = new Triangle.points(
+      _v(0.0, 1.5, 1.0), _v(2.0, 1.5, 1.0), _v(1.0, 1.5, 3.0));
+  final outside = new Triangle.points(
+      _v(2.0, 2.0, 0.0), _v(2.0, 6.0, 0.0), _v(2.0, 2.0, 3.0));
+  final behind = new Triangle.points(
+      _v(0.0, 0.0, 0.0), _v(0.0, 3.0, 0.0), _v(0.0, 3.0, 4.0));
 
-  expect(parent.intersectsWithTriangle(hitting), equals(2.0));
-  expect(parent.intersectsWithTriangle(cutting), equals(0.5));
+  absoluteTest(parent.intersectsWithTriangle(hitting), 2.0);
+  absoluteTest(parent.intersectsWithTriangle(cutting), 0.5);
   expect(parent.intersectsWithTriangle(outside), equals(null));
   expect(parent.intersectsWithTriangle(behind), equals(null));
 
   // Test cases from real-world failures:
   // Just barely intersects, but gets rounded out
-  final Ray p2 = new Ray.originDirection(
-      v3(0.0, -0.16833500564098358, 0.7677000164985657),
-      v3(-0.0, -0.8124330043792725, -0.5829949975013733));
-  final Triangle t2 = new Triangle.points(
-      v3(0.03430179879069328, -0.7268069982528687, 0.3532710075378418),
-      v3(0.0, -0.7817990183830261, 0.3641969859600067),
-      v3(0.0, -0.7293699979782104, 0.3516849875450134));
-  expect(p2.intersectsWithTriangle(t2), closeTo(0.7078371874391822, 1e-10));
+  final p2 = new Ray.originDirection(
+      _v(0.0, -0.16833500564098358, 0.7677000164985657),
+      _v(-0.0, -0.8124330043792725, -0.5829949975013733));
+  final t2 = new Triangle.points(
+      _v(0.03430179879069328, -0.7268069982528687, 0.3532710075378418),
+      _v(0.0, -0.7817990183830261, 0.3641969859600067),
+      _v(0.0, -0.7293699979782104, 0.3516849875450134));
+
+  absoluteTest(p2.intersectsWithTriangle(t2), 0.7078371874391822);
+
   // Ray is not quite perpendicular to triangle, but gets rounded out
-  final Ray p3 = new Ray.originDirection(
-      v3(0.023712199181318283, -0.15045200288295746, 0.7751160264015198),
-      v3(0.6024960279464722, -0.739005982875824, -0.3013699948787689));
-  final Triangle t3 = new Triangle.points(
-      v3(0.16174300014972687, -0.3446039855480194, 0.7121580243110657),
-      v3(0.1857299953699112, -0.3468630015850067, 0.6926270127296448),
-      v3(0.18045000731945038, -0.3193660080432892, 0.6921690106391907));
-  expect(p3.intersectsWithTriangle(t3), closeTo(0.2538471189773835, 1e-10));
+  final p3 = new Ray.originDirection(
+      _v(0.023712199181318283, -0.15045200288295746, 0.7751160264015198),
+      _v(0.6024960279464722, -0.739005982875824, -0.3013699948787689));
+  final t3 = new Triangle.points(
+      _v(0.16174300014972687, -0.3446039855480194, 0.7121580243110657),
+      _v(0.1857299953699112, -0.3468630015850067, 0.6926270127296448),
+      _v(0.18045000731945038, -0.3193660080432892, 0.6921690106391907));
+
+  absoluteTest(p3.intersectsWithTriangle(t3), 0.2538471189773835);
 }
 
-void testRayIntersectionAabb3() {
-  final Ray parent =
-      new Ray.originDirection(v3(1.0, 1.0, 1.0), v3(0.0, 1.0, 0.0));
-  final Aabb3 hitting =
-      new Aabb3.minMax(v3(0.5, 3.5, -10.0), v3(2.5, 5.5, 10.0));
-  final Aabb3 cutting = new Aabb3.minMax(v3(0.0, 2.0, 1.0), v3(2.0, 3.0, 2.0));
-  final Aabb3 outside = new Aabb3.minMax(v3(2.0, 0.0, 0.0), v3(6.0, 6.0, 6.0));
-  final Aabb3 behind = new Aabb3.minMax(v3(0.0, -2.0, 0.0), v3(2.0, 0.0, 2.0));
-  final Aabb3 inside = new Aabb3.minMax(v3(0.0, 0.0, 0.0), v3(2.0, 2.0, 2.0));
+void testIntersectionAabb3() {
+  final parent = new Ray.originDirection(_v(1.0, 1.0, 1.0), _v(0.0, 1.0, 0.0));
+  final hitting = new Aabb3.minMax(_v(0.5, 3.5, -10.0), _v(2.5, 5.5, 10.0));
+  final cutting = new Aabb3.minMax(_v(0.0, 2.0, 1.0), _v(2.0, 3.0, 2.0));
+  final outside = new Aabb3.minMax(_v(2.0, 0.0, 0.0), _v(6.0, 6.0, 6.0));
+  final behind = new Aabb3.minMax(_v(0.0, -2.0, 0.0), _v(2.0, 0.0, 2.0));
+  final inside = new Aabb3.minMax(_v(0.0, 0.0, 0.0), _v(2.0, 2.0, 2.0));
 
   expect(parent.intersectsWithAabb3(hitting), equals(2.5));
   expect(parent.intersectsWithAabb3(cutting), equals(1.0));
@@ -102,9 +118,15 @@ void testRayIntersectionAabb3() {
   expect(parent.intersectsWithAabb3(inside), equals(-1.0));
 }
 
+Vector3 _v(double x, double y, double z) {
+  return new Vector3(x, y, z);
+}
+
 void main() {
-  test('Ray At', testRayAt);
-  test('Ray Intersection Sphere', testRayIntersectionSphere);
-  test('Ray Intersection Triangle', testRayIntersectionTriangle);
-  test('Ray Intersection Aabb3', testRayIntersectionAabb3);
+  group('Ray', () {
+    test('At', testAt);
+    test('Intersection Sphere', testIntersectionSphere);
+    test('Intersection Triangle', testIntersectionTriangle);
+    test('Intersection Aabb3', testIntersectionAabb3);
+  });
 }


### PR DESCRIPTION
* Improve performance of intersection tests by avoiding allocations. This is archived by creating static variables that are reused on every execution.
* Remove unnecessary type annotations in ray_test
* Fix link in readme, was missing http://
