### PR TITLE
Cleanup aabb

### DIFF
--- a/lib/src/vector_math/aabb2.dart
+++ b/lib/src/vector_math/aabb2.dart
@@ -4,102 +4,126 @@
 
 part of vector_math;
 
+/// Defines a 2-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb2 {
   final Vector2 _min;
   final Vector2 _max;
 
+  /// The minimum point defining the AABB.
   Vector2 get min => _min;
+  /// The maximum point defining the AABB.
   Vector2 get max => _max;
 
-  Vector2 get center {
-    Vector2 c = new Vector2.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector2 get center => _min.clone()
+    ..add(_max)
+    ..scale(0.5);
 
+  /// Create a new AABB with [min] and [max] set to the origin.
   Aabb2()
       : _min = new Vector2.zero(),
         _max = new Vector2.zero();
 
+  /// Create a new AABB as a copy of [other].
   Aabb2.copy(Aabb2 other)
       : _min = new Vector2.copy(other._min),
         _max = new Vector2.copy(other._max);
 
-  @deprecated
-  Aabb2.minmax(Vector2 min_, Vector2 max_)
-      : _min = new Vector2.copy(min_),
-        _max = new Vector2.copy(max_);
+  /// Create a new AABB with a [min] and [max].
+  Aabb2.minMax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  Aabb2.minMax(Vector2 min_, Vector2 max_)
-      : _min = new Vector2.copy(min_),
-        _max = new Vector2.copy(max_);
+  /// Create a new AABB with a [center] and [halfExtents].
+  factory Aabb2.centerAndHalfExtents(Vector2 center, Vector2 halfExtents) =>
+      new Aabb2()..setCenterAndHalfExtents(center, halfExtents);
 
-  void copyMinMax(Vector2 min_, Vector2 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
+  /// Constructs [Aabb2] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float32List.BYTES_PER_ELEMENT].
+  Aabb2.fromBuffer(ByteBuffer buffer, int offset)
+      : _min = new Vector2.fromBuffer(buffer, offset),
+        _max = new Vector2.fromBuffer(
+            buffer, offset + Float32List.BYTES_PER_ELEMENT * 2);
+
+  /// Set the AABB by a [center] and [halfExtents].
+  void setCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
   }
 
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
+    halfExtents
+      ..setFrom(_max)
+      ..sub(_min)
+      ..scale(0.5);
   }
 
-  void copyFrom(Aabb2 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb2 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb2 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
-  }
-
-  Aabb2 transform(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Transform [this] by the transform [t].
+  Aabb2 transform(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform2(center);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t
+      ..transform2(center)
+      ..absoluteRotate2(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb2 rotate(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  Aabb2 rotate(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t.absoluteRotate2(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb2 transformed(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb2 transformed(Matrix3 t, Aabb2 out) => out
+    ..copyFrom(this)
+    ..transform(t);
 
-  Aabb2 rotated(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb2 rotated(Matrix3 t, Aabb2 out) => out
+    ..copyFrom(this)
+    ..rotate(t);
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb2 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
+    Vector2.min(_min, other._min, _min);
+    Vector2.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -110,33 +134,39 @@ class Aabb2 {
 
   /// Return if [this] contains [other].
   bool containsAabb2(Aabb2 other) {
-    return min.x < other.min.x &&
-        min.y < other.min.y &&
-        max.y > other.max.y &&
-        max.x > other.max.x;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x < otherMin.x) &&
+        (_min.y < otherMin.y) &&
+        (_max.y > otherMax.y) &&
+        (_max.x > otherMax.x);
   }
 
   /// Return if [this] contains [other].
   bool containsVector2(Vector2 other) {
-    return min.x < other.x &&
-        min.y < other.y &&
-        max.x > other.x &&
-        max.y > other.y;
+    return (_min.x < other.x) &&
+        (_min.y < other.y) &&
+        (_max.x > other.x) &&
+        (_max.y > other.y);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb2(Aabb2 other) {
-    return min.x <= other.max.x &&
-        min.y <= other.max.y &&
-        max.x >= other.min.x &&
-        max.y >= other.min.y;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x <= otherMax.x) &&
+        (_min.y <= otherMax.y) &&
+        (_max.x >= otherMin.x) &&
+        (_max.y >= otherMin.y);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector2(Vector2 other) {
-    return min.x <= other.x &&
-        min.y <= other.y &&
-        max.x >= other.x &&
-        max.y >= other.y;
+    return (_min.x <= other.x) &&
+        (_min.y <= other.y) &&
+        (_max.x >= other.x) &&
+        (_max.y >= other.y);
   }
 }

--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -4,6 +4,12 @@
 
 part of vector_math;
 
+//TODO (fox32): Add setObb, fromObb
+//TODO (fox32): Add intersectsWithTriangle, intersectsWithPlane,
+// intersectsWithQuad and IntersectionResult
+
+/// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb3 {
   final Vector3 _min;
   final Vector3 _max;
@@ -11,114 +17,229 @@ class Aabb3 {
   Vector3 get min => _min;
   Vector3 get max => _max;
 
-  Vector3 get center {
-    Vector3 c = new Vector3.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector3 get center => _min.clone()
+    ..add(_max)
+    ..scale(0.5);
 
+  /// Create a new AABB with [min] and [max] set to the origin.
   Aabb3()
       : _min = new Vector3.zero(),
         _max = new Vector3.zero();
 
+  /// Create a new AABB as a copy of [other].
   Aabb3.copy(Aabb3 other)
       : _min = new Vector3.copy(other._min),
         _max = new Vector3.copy(other._max);
 
-  @deprecated
-  Aabb3.minmax(Vector3 min_, Vector3 max_)
-      : _min = new Vector3.copy(min_),
-        _max = new Vector3.copy(max_);
+  /// Create a new AABB with a [min] and [max].
+  Aabb3.minMax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
-  Aabb3.minMax(Vector3 min_, Vector3 max_)
-      : _min = new Vector3.copy(min_),
-        _max = new Vector3.copy(max_);
+  /// Create a new AABB that encloses a [sphere].
+  factory Aabb3.fromSphere(Sphere sphere) => new Aabb3()..setSphere(sphere);
 
-  void copyMinMax(Vector3 min_, Vector3 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
-  }
+  /// Create a new AABB that encloses a [triangle].
+  factory Aabb3.fromTriangle(Triangle triangle) =>
+      new Aabb3()..setTriangle(triangle);
 
-  /// Constructs Aabb3 with a min/max [storage] that views given [buffer] starting at [offset].
-  /// [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
+  /// Create a new AABB that encloses a [quad].
+  factory Aabb3.fromQuad(Quad quad) => new Aabb3()..setQuad(quad);
+
+  /// Create a new AABB that encloses a limited [ray] (or line segment) that has
+  /// a minLimit and maxLimit.
+  factory Aabb3.fromRay(Ray ray, double limitMin, double limitMax) =>
+      new Aabb3()..setRay(ray, limitMin, limitMax);
+
+  /// Create a new AABB with a [center] and [halfExtents].
+  factory Aabb3.centerAndHalfExtents(Vector3 center, Vector3 halfExtents) =>
+      new Aabb3()..setCenterAndHalfExtents(center, halfExtents);
+
+  /// Constructs [Aabb3] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float32List.BYTES_PER_ELEMENT].
   Aabb3.fromBuffer(ByteBuffer buffer, int offset)
       : _min = new Vector3.fromBuffer(buffer, offset),
         _max = new Vector3.fromBuffer(
             buffer, offset + Float32List.BYTES_PER_ELEMENT * 3);
 
+  /// Set the AABB by a [center] and [halfExtents].
+  void setCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
+  }
+
+  /// Set the AABB to enclose a [sphere].
+  void setSphere(Sphere sphere) {
+    _min
+      ..splat(-sphere._radius)
+      ..add(sphere._center);
+    _max
+      ..splat(sphere._radius)
+      ..add(sphere._center);
+  }
+
+  /// Set the AABB to enclose a [triangle].
+  void setTriangle(Triangle triangle) {
+    _min.setValues(Math.min(triangle._point0.x,
+        Math.min(triangle._point1.x, triangle._point2.x)), Math.min(
+        triangle._point0.y,
+        Math.min(triangle._point1.y, triangle._point2.y)), Math.min(
+        triangle._point0.z, Math.min(triangle._point1.z, triangle._point2.z)));
+    _max.setValues(Math.max(triangle._point0.x,
+        Math.max(triangle._point1.x, triangle._point2.x)), Math.max(
+        triangle._point0.y,
+        Math.max(triangle._point1.y, triangle._point2.y)), Math.max(
+        triangle._point0.z, Math.max(triangle._point1.z, triangle._point2.z)));
+  }
+
+  /// Set the AABB to enclose a [quad].
+  void setQuad(Quad quad) {
+    _min.setValues(Math.min(quad._point0.x,
+            Math.min(quad._point1.x, Math.min(quad._point2.x, quad._point3.x))),
+        Math.min(quad._point0.y,
+            Math.min(quad._point1.y, Math.min(quad._point2.y, quad._point3.y))),
+        Math.min(quad._point0.z, Math.min(
+            quad._point1.z, Math.min(quad._point2.z, quad._point3.z))));
+    _max.setValues(Math.max(quad._point0.x,
+            Math.max(quad._point1.x, Math.max(quad._point2.x, quad._point3.x))),
+        Math.max(quad._point0.y,
+            Math.max(quad._point1.y, Math.max(quad._point2.y, quad._point3.y))),
+        Math.max(quad._point0.z, Math.max(
+            quad._point1.z, Math.max(quad._point2.z, quad._point3.z))));
+  }
+
+  /// Set the AABB to enclose a limited [ray] (or line segment) that is limited
+  /// by [limitMin] and [limitMax].
+  void setRay(Ray ray, double limitMin, double limitMax) {
+    ray.copyAt(_min, limitMin);
+    ray.copyAt(_max, limitMax);
+
+    if (_max.x < _min.x) {
+      final temp = _max.x;
+      _max.x = _min.x;
+      _min.x = temp;
+    }
+
+    if (_max.y < _min.y) {
+      final temp = _max.y;
+      _max.y = _min.y;
+      _min.y = temp;
+    }
+
+    if (_max.z < _min.z) {
+      final temp = _max.z;
+      _max.z = _min.z;
+      _min.z = temp;
+    }
+  }
+
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
+    halfExtents
+      ..setFrom(_max)
+      ..sub(_min)
+      ..scale(0.5);
   }
 
-  void copyFrom(Aabb3 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [center] of [this].
+  void copyCenter(Vector3 center) {
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
   }
 
-  void copyInto(Aabb3 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb3 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  Aabb3 transform(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Transform [this] by the transform [t].
+  Aabb3 transform(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform3(center);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t
+      ..transform3(center)
+      ..absoluteRotate(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb3 rotate(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  Aabb3 rotate(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t.absoluteRotate(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb3 transformed(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb3 transformed(Matrix4 t, Aabb3 out) => out
+    ..copyFrom(this)
+    ..transform(t);
 
-  Aabb3 rotated(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb3 rotated(Matrix4 t, Aabb3 out) => out
+    ..copyFrom(this)
+    ..rotate(t);
 
   void getPN(Vector3 planeNormal, Vector3 outP, Vector3 outN) {
-    outP.x = planeNormal.x < 0.0 ? _min.x : _max.x;
-    outP.y = planeNormal.y < 0.0 ? _min.y : _max.y;
-    outP.z = planeNormal.z < 0.0 ? _min.z : _max.z;
+    if (planeNormal.x < 0.0) {
+      outP.x = _min.x;
+      outN.x = _max.x;
+    } else {
+      outP.x = _max.x;
+      outN.x = _min.x;
+    }
 
-    outN.x = planeNormal.x < 0.0 ? _max.x : _min.x;
-    outN.y = planeNormal.y < 0.0 ? _max.y : _min.y;
-    outN.z = planeNormal.z < 0.0 ? _max.z : _min.z;
+    if (planeNormal.y < 0.0) {
+      outP.y = _min.y;
+      outN.y = _max.y;
+    } else {
+      outP.y = _max.y;
+      outN.y = _min.y;
+    }
+
+    if (planeNormal.z < 0.0) {
+      outP.z = _min.z;
+      outN.z = _max.z;
+    } else {
+      outP.z = _max.z;
+      outN.z = _min.z;
+    }
   }
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb3 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    min.z = Math.min(_min.z, other.min.z);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
-    max.z = Math.max(_max.z, other.max.y);
+    Vector3.min(_min, other._min, _min);
+    Vector3.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -129,81 +250,88 @@ class Aabb3 {
 
   /// Return if [this] contains [other].
   bool containsAabb3(Aabb3 other) {
-    return min.x < other.min.x &&
-        min.y < other.min.y &&
-        min.z < other.min.z &&
-        max.x > other.max.x &&
-        max.y > other.max.y &&
-        max.z > other.max.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x < otherMin.x) &&
+        (_min.y < otherMin.y) &&
+        (_min.z < otherMin.z) &&
+        (_max.x > otherMax.x) &&
+        (_max.y > otherMax.y) &&
+        (_max.z > otherMax.z);
   }
 
   /// Return if [this] contains [other].
   bool containsSphere(Sphere other) {
-    final sphereExtends = new Vector3.zero().splat(other.radius);
-    final sphereBox = new Aabb3.minMax(other.center.clone().sub(sphereExtends),
-        other.center.clone().add(sphereExtends));
+    final boxExtends = new Vector3.all(other._radius);
+    final sphereBox = new Aabb3.centerAndHalfExtents(other._center, boxExtends);
 
     return containsAabb3(sphereBox);
   }
 
   /// Return if [this] contains [other].
   bool containsVector3(Vector3 other) {
-    return min.x < other.x &&
-        min.y < other.y &&
-        min.z < other.z &&
-        max.x > other.x &&
-        max.y > other.y &&
-        max.z > other.z;
+    return (_min.x < other.x) &&
+        (_min.y < other.y) &&
+        (_min.z < other.z) &&
+        (_max.x > other.x) &&
+        (_max.y > other.y) &&
+        (_max.z > other.z);
   }
 
   /// Return if [this] contains [other].
-  bool containsTriangle(Triangle other) {
-    return containsVector3(other.point0) &&
-        containsVector3(other.point1) &&
-        containsVector3(other.point2);
-  }
+  bool containsTriangle(Triangle other) => containsVector3(other._point0) &&
+      containsVector3(other._point1) &&
+      containsVector3(other._point2);
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb3(Aabb3 other) {
-    return min.x <= other.max.x &&
-        min.y <= other.max.y &&
-        min.z <= other.max.z &&
-        max.x >= other.min.x &&
-        max.y >= other.min.y &&
-        max.z >= other.min.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x <= otherMax.x) &&
+        (_min.y <= otherMax.y) &&
+        (_min.z <= otherMax.z) &&
+        (_max.x >= otherMin.x) &&
+        (_max.y >= otherMin.y) &&
+        (_max.z >= otherMin.z);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithSphere(Sphere other) {
-    double d = 0.0;
-    double e = 0.0;
+    final center = other._center;
+    final radius = other._radius;
+    var d = 0.0;
+    var e = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-      if ((e = other.center[i] - min[i]) < 0.0) {
-        if (e < -other.radius) {
+    for (var i = 0; i < 3; ++i) {
+      if ((e = center[i] - _min[i]) < 0.0) {
+        if (e < -radius) {
           return false;
         }
 
         d = d + e * e;
-      } else if ((e = other.center[i] - max[i]) > 0.0) {
-        if (e > other.radius) {
-          return false;
-        }
+      } else {
+        if ((e = center[i] - _max[i]) > 0.0) {
+          if (e > radius) {
+            return false;
+          }
 
-        d = d + e * e;
+          d = d + e * e;
+        }
       }
     }
 
-    return d <= other.radius * other.radius;
+    return d <= radius * radius;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector3(Vector3 other) {
-    return min.x <= other.x &&
-        min.y <= other.y &&
-        min.z <= other.z &&
-        max.x >= other.x &&
-        max.y >= other.y &&
-        max.z >= other.z;
+    return (_min.x <= other.x) &&
+        (_min.y <= other.y) &&
+        (_min.z <= other.z) &&
+        (_max.x >= other.x) &&
+        (_max.y >= other.y) &&
+        (_max.z >= other.z);
   }
 }

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -6,7 +6,7 @@ part of vector_math;
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float32List storage = new Float32List(2);
+  final Float32List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -27,28 +27,32 @@ class Vector2 implements Vector {
     result.y = min.y + a * (max.y - min.y);
   }
 
+
+
   /// Construct a new vector with the specified values.
-  Vector2(double x_, double y_) {
-    setValues(x_, y_);
-  }
+  factory Vector2(double x, double y) => new Vector2.zero()..setValues(x, y);
 
   /// Initialized with values from [array] starting at [offset].
-  Vector2.array(List<double> array, [int offset = 0]) {
-    int i = offset;
-    storage[1] = array[i + 1];
-    storage[0] = array[i + 0];
-  }
+  factory Vector2.array(List<double> array, [int offset = 0]) =>
+      new Vector2.zero()..copyFromArray(array, offset);
 
   /// Zero vector.
-  Vector2.zero();
+  Vector2.zero()
+      : storage = new Float32List(2);
 
   /// Splat [value] into all lanes of the vector.
-  Vector2.all(double value) : this(value, value);
+  factory Vector2.all(double value) => new Vector2.zero()..splat(value);
 
   /// Copy of [other].
-  Vector2.copy(Vector2 other) {
-    setFrom(other);
-  }
+  factory Vector2.copy(Vector2 other) => new Vector2.zero()..setFrom(other);
+
+  /// Constructs Vector2 with given Float32List as [storage].
+  Vector2.fromFloat32List(this.storage);
+
+  /// Constructs Vector2 with a [storage] that views given [buffer] starting at
+  /// [offset]. [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
+  Vector2.fromBuffer(ByteBuffer buffer, int offset)
+      : storage = new Float32List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
   Vector2 setValues(double x_, double y_) {

--- a/lib/src/vector_math_64/aabb2.dart
+++ b/lib/src/vector_math_64/aabb2.dart
@@ -4,102 +4,126 @@
 
 part of vector_math_64;
 
+/// Defines a 2-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb2 {
   final Vector2 _min;
   final Vector2 _max;
 
+  /// The minimum point defining the AABB.
   Vector2 get min => _min;
+  /// The maximum point defining the AABB.
   Vector2 get max => _max;
 
-  Vector2 get center {
-    Vector2 c = new Vector2.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector2 get center => _min.clone()
+    ..add(_max)
+    ..scale(0.5);
 
+  /// Create a new AABB with [min] and [max] set to the origin.
   Aabb2()
       : _min = new Vector2.zero(),
         _max = new Vector2.zero();
 
+  /// Create a new AABB as a copy of [other].
   Aabb2.copy(Aabb2 other)
       : _min = new Vector2.copy(other._min),
         _max = new Vector2.copy(other._max);
 
-  @deprecated
-  Aabb2.minmax(Vector2 min_, Vector2 max_)
-      : _min = new Vector2.copy(min_),
-        _max = new Vector2.copy(max_);
+  /// Create a new AABB with a [min] and [max].
+  Aabb2.minMax(Vector2 min, Vector2 max)
+      : _min = new Vector2.copy(min),
+        _max = new Vector2.copy(max);
 
-  Aabb2.minMax(Vector2 min_, Vector2 max_)
-      : _min = new Vector2.copy(min_),
-        _max = new Vector2.copy(max_);
+  /// Create a new AABB with a [center] and [halfExtents].
+  factory Aabb2.centerAndHalfExtents(Vector2 center, Vector2 halfExtents) =>
+      new Aabb2()..setCenterAndHalfExtents(center, halfExtents);
 
-  void copyMinMax(Vector2 min_, Vector2 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
+  /// Constructs [Aabb2] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float64List.BYTES_PER_ELEMENT].
+  Aabb2.fromBuffer(ByteBuffer buffer, int offset)
+      : _min = new Vector2.fromBuffer(buffer, offset),
+        _max = new Vector2.fromBuffer(
+            buffer, offset + Float64List.BYTES_PER_ELEMENT * 2);
+
+  /// Set the AABB by a [center] and [halfExtents].
+  void setCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
   }
 
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector2 center, Vector2 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
+    halfExtents
+      ..setFrom(_max)
+      ..sub(_min)
+      ..scale(0.5);
   }
 
-  void copyFrom(Aabb2 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb2 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  void copyInto(Aabb2 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
-  }
-
-  Aabb2 transform(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Transform [this] by the transform [t].
+  Aabb2 transform(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform2(center);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t
+      ..transform2(center)
+      ..absoluteRotate2(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb2 rotate(Matrix3 T) {
-    Vector2 center = new Vector2.zero();
-    Vector2 halfExtents = new Vector2.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  Aabb2 rotate(Matrix3 t) {
+    final center = new Vector2.zero();
+    final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate2(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t.absoluteRotate2(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb2 transformed(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb2 transformed(Matrix3 t, Aabb2 out) => out
+    ..copyFrom(this)
+    ..transform(t);
 
-  Aabb2 rotated(Matrix3 T, Aabb2 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb2 rotated(Matrix3 t, Aabb2 out) => out
+    ..copyFrom(this)
+    ..rotate(t);
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb2 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
+    Vector2.min(_min, other._min, _min);
+    Vector2.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -110,33 +134,39 @@ class Aabb2 {
 
   /// Return if [this] contains [other].
   bool containsAabb2(Aabb2 other) {
-    return min.x < other.min.x &&
-        min.y < other.min.y &&
-        max.y > other.max.y &&
-        max.x > other.max.x;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x < otherMin.x) &&
+        (_min.y < otherMin.y) &&
+        (_max.y > otherMax.y) &&
+        (_max.x > otherMax.x);
   }
 
   /// Return if [this] contains [other].
   bool containsVector2(Vector2 other) {
-    return min.x < other.x &&
-        min.y < other.y &&
-        max.x > other.x &&
-        max.y > other.y;
+    return (_min.x < other.x) &&
+        (_min.y < other.y) &&
+        (_max.x > other.x) &&
+        (_max.y > other.y);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb2(Aabb2 other) {
-    return min.x <= other.max.x &&
-        min.y <= other.max.y &&
-        max.x >= other.min.x &&
-        max.y >= other.min.y;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x <= otherMax.x) &&
+        (_min.y <= otherMax.y) &&
+        (_max.x >= otherMin.x) &&
+        (_max.y >= otherMin.y);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector2(Vector2 other) {
-    return min.x <= other.x &&
-        min.y <= other.y &&
-        max.x >= other.x &&
-        max.y >= other.y;
+    return (_min.x <= other.x) &&
+        (_min.y <= other.y) &&
+        (_max.x >= other.x) &&
+        (_max.y >= other.y);
   }
 }

--- a/lib/src/vector_math_64/aabb3.dart
+++ b/lib/src/vector_math_64/aabb3.dart
@@ -4,6 +4,12 @@
 
 part of vector_math_64;
 
+//TODO (fox32): Add setObb, fromObb
+//TODO (fox32): Add intersectsWithTriangle, intersectsWithPlane,
+// intersectsWithQuad and IntersectionResult
+
+/// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
+/// [max] position.
 class Aabb3 {
   final Vector3 _min;
   final Vector3 _max;
@@ -11,114 +17,229 @@ class Aabb3 {
   Vector3 get min => _min;
   Vector3 get max => _max;
 
-  Vector3 get center {
-    Vector3 c = new Vector3.copy(_min);
-    return c.add(_max).scale(.5);
-  }
+  /// The center of the AABB.
+  Vector3 get center => _min.clone()
+    ..add(_max)
+    ..scale(0.5);
 
+  /// Create a new AABB with [min] and [max] set to the origin.
   Aabb3()
       : _min = new Vector3.zero(),
         _max = new Vector3.zero();
 
+  /// Create a new AABB as a copy of [other].
   Aabb3.copy(Aabb3 other)
       : _min = new Vector3.copy(other._min),
         _max = new Vector3.copy(other._max);
 
-  @deprecated
-  Aabb3.minmax(Vector3 min_, Vector3 max_)
-      : _min = new Vector3.copy(min_),
-        _max = new Vector3.copy(max_);
+  /// Create a new AABB with a [min] and [max].
+  Aabb3.minMax(Vector3 min, Vector3 max)
+      : _min = new Vector3.copy(min),
+        _max = new Vector3.copy(max);
 
-  Aabb3.minMax(Vector3 min_, Vector3 max_)
-      : _min = new Vector3.copy(min_),
-        _max = new Vector3.copy(max_);
+  /// Create a new AABB that encloses a [sphere].
+  factory Aabb3.fromSphere(Sphere sphere) => new Aabb3()..setSphere(sphere);
 
-  void copyMinMax(Vector3 min_, Vector3 max_) {
-    max_.setFrom(_max);
-    min_.setFrom(_min);
-  }
+  /// Create a new AABB that encloses a [triangle].
+  factory Aabb3.fromTriangle(Triangle triangle) =>
+      new Aabb3()..setTriangle(triangle);
 
-  /// Constructs Aabb3 with a min/max [storage] that views given [buffer] starting at [offset].
-  /// [offset] has to be multiple of [Float64List.BYTES_PER_ELEMENT].
+  /// Create a new AABB that encloses a [quad].
+  factory Aabb3.fromQuad(Quad quad) => new Aabb3()..setQuad(quad);
+
+  /// Create a new AABB that encloses a limited [ray] (or line segment) that has
+  /// a minLimit and maxLimit.
+  factory Aabb3.fromRay(Ray ray, double limitMin, double limitMax) =>
+      new Aabb3()..setRay(ray, limitMin, limitMax);
+
+  /// Create a new AABB with a [center] and [halfExtents].
+  factory Aabb3.centerAndHalfExtents(Vector3 center, Vector3 halfExtents) =>
+      new Aabb3()..setCenterAndHalfExtents(center, halfExtents);
+
+  /// Constructs [Aabb3] with a min/max [storage] that views given [buffer]
+  /// starting at [offset]. [offset] has to be multiple of
+  /// [Float64List.BYTES_PER_ELEMENT].
   Aabb3.fromBuffer(ByteBuffer buffer, int offset)
       : _min = new Vector3.fromBuffer(buffer, offset),
         _max = new Vector3.fromBuffer(
             buffer, offset + Float64List.BYTES_PER_ELEMENT * 3);
 
+  /// Set the AABB by a [center] and [halfExtents].
+  void setCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
+  }
+
+  /// Set the AABB to enclose a [sphere].
+  void setSphere(Sphere sphere) {
+    _min
+      ..splat(-sphere._radius)
+      ..add(sphere._center);
+    _max
+      ..splat(sphere._radius)
+      ..add(sphere._center);
+  }
+
+  /// Set the AABB to enclose a [triangle].
+  void setTriangle(Triangle triangle) {
+    _min.setValues(Math.min(triangle._point0.x,
+        Math.min(triangle._point1.x, triangle._point2.x)), Math.min(
+        triangle._point0.y,
+        Math.min(triangle._point1.y, triangle._point2.y)), Math.min(
+        triangle._point0.z, Math.min(triangle._point1.z, triangle._point2.z)));
+    _max.setValues(Math.max(triangle._point0.x,
+        Math.max(triangle._point1.x, triangle._point2.x)), Math.max(
+        triangle._point0.y,
+        Math.max(triangle._point1.y, triangle._point2.y)), Math.max(
+        triangle._point0.z, Math.max(triangle._point1.z, triangle._point2.z)));
+  }
+
+  /// Set the AABB to enclose a [quad].
+  void setQuad(Quad quad) {
+    _min.setValues(Math.min(quad._point0.x,
+            Math.min(quad._point1.x, Math.min(quad._point2.x, quad._point3.x))),
+        Math.min(quad._point0.y,
+            Math.min(quad._point1.y, Math.min(quad._point2.y, quad._point3.y))),
+        Math.min(quad._point0.z, Math.min(
+            quad._point1.z, Math.min(quad._point2.z, quad._point3.z))));
+    _max.setValues(Math.max(quad._point0.x,
+            Math.max(quad._point1.x, Math.max(quad._point2.x, quad._point3.x))),
+        Math.max(quad._point0.y,
+            Math.max(quad._point1.y, Math.max(quad._point2.y, quad._point3.y))),
+        Math.max(quad._point0.z, Math.max(
+            quad._point1.z, Math.max(quad._point2.z, quad._point3.z))));
+  }
+
+  /// Set the AABB to enclose a limited [ray] (or line segment) that is limited
+  /// by [limitMin] and [limitMax].
+  void setRay(Ray ray, double limitMin, double limitMax) {
+    ray.copyAt(_min, limitMin);
+    ray.copyAt(_max, limitMax);
+
+    if (_max.x < _min.x) {
+      final temp = _max.x;
+      _max.x = _min.x;
+      _min.x = temp;
+    }
+
+    if (_max.y < _min.y) {
+      final temp = _max.y;
+      _max.y = _min.y;
+      _min.y = temp;
+    }
+
+    if (_max.z < _min.z) {
+      final temp = _max.z;
+      _max.z = _min.z;
+      _min.z = temp;
+    }
+  }
+
+  /// Copy the [center] and the [halfExtends] of [this].
   void copyCenterAndHalfExtents(Vector3 center, Vector3 halfExtents) {
-    center.setFrom(_min);
-    center.add(_max);
-    center.scale(0.5);
-    halfExtents.setFrom(_max);
-    halfExtents.sub(_min);
-    halfExtents.scale(0.5);
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
+    halfExtents
+      ..setFrom(_max)
+      ..sub(_min)
+      ..scale(0.5);
   }
 
-  void copyFrom(Aabb3 o) {
-    _min.setFrom(o._min);
-    _max.setFrom(o._max);
+  /// Copy the [center] of [this].
+  void copyCenter(Vector3 center) {
+    center
+      ..setFrom(_min)
+      ..add(_max)
+      ..scale(0.5);
   }
 
-  void copyInto(Aabb3 o) {
-    o._min.setFrom(_min);
-    o._max.setFrom(_max);
+  /// Copy the [min] and [max] from [other] into [this].
+  void copyFrom(Aabb3 other) {
+    _min.setFrom(other._min);
+    _max.setFrom(other._max);
   }
 
-  Aabb3 transform(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Transform [this] by the transform [t].
+  Aabb3 transform(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.transform3(center);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t
+      ..transform3(center)
+      ..absoluteRotate(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb3 rotate(Matrix4 T) {
-    Vector3 center = new Vector3.zero();
-    Vector3 halfExtents = new Vector3.zero();
+  /// Rotate [this] by the rotation matrix [t].
+  Aabb3 rotate(Matrix4 t) {
+    final center = new Vector3.zero();
+    final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
-    T.absoluteRotate(halfExtents);
-    _min.setFrom(center);
-    _max.setFrom(center);
-
-    _min.sub(halfExtents);
-    _max.add(halfExtents);
+    t.absoluteRotate(halfExtents);
+    _min
+      ..setFrom(center)
+      ..sub(halfExtents);
+    _max
+      ..setFrom(center)
+      ..add(halfExtents);
     return this;
   }
 
-  Aabb3 transformed(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.transform(T);
-  }
+  /// Create a copy of [this] that is transformed by the transform [t] and store
+  /// it in [out].
+  Aabb3 transformed(Matrix4 t, Aabb3 out) => out
+    ..copyFrom(this)
+    ..transform(t);
 
-  Aabb3 rotated(Matrix4 T, Aabb3 out) {
-    out.copyFrom(this);
-    return out.rotate(T);
-  }
+  /// Create a copy of [this] that is rotated by the rotation matrix [t] and
+  /// store it in [out].
+  Aabb3 rotated(Matrix4 t, Aabb3 out) => out
+    ..copyFrom(this)
+    ..rotate(t);
 
   void getPN(Vector3 planeNormal, Vector3 outP, Vector3 outN) {
-    outP.x = planeNormal.x < 0.0 ? _min.x : _max.x;
-    outP.y = planeNormal.y < 0.0 ? _min.y : _max.y;
-    outP.z = planeNormal.z < 0.0 ? _min.z : _max.z;
+    if (planeNormal.x < 0.0) {
+      outP.x = _min.x;
+      outN.x = _max.x;
+    } else {
+      outP.x = _max.x;
+      outN.x = _min.x;
+    }
 
-    outN.x = planeNormal.x < 0.0 ? _max.x : _min.x;
-    outN.y = planeNormal.y < 0.0 ? _max.y : _min.y;
-    outN.z = planeNormal.z < 0.0 ? _max.z : _min.z;
+    if (planeNormal.y < 0.0) {
+      outP.y = _min.y;
+      outN.y = _max.y;
+    } else {
+      outP.y = _max.y;
+      outN.y = _min.y;
+    }
+
+    if (planeNormal.z < 0.0) {
+      outP.z = _min.z;
+      outN.z = _max.z;
+    } else {
+      outP.z = _max.z;
+      outN.z = _min.z;
+    }
   }
 
-  /// Set the min and max of [this] so that [this] is a hull of [this] and [other].
+  /// Set the min and max of [this] so that [this] is a hull of [this] and
+  /// [other].
   void hull(Aabb3 other) {
-    min.x = Math.min(_min.x, other.min.x);
-    min.y = Math.min(_min.y, other.min.y);
-    min.z = Math.min(_min.z, other.min.z);
-    max.x = Math.max(_max.x, other.max.x);
-    max.y = Math.max(_max.y, other.max.y);
-    max.z = Math.max(_max.z, other.max.y);
+    Vector3.min(_min, other._min, _min);
+    Vector3.max(_max, other._max, _max);
   }
 
   /// Set the min and max of [this] so that [this] contains [point].
@@ -129,81 +250,88 @@ class Aabb3 {
 
   /// Return if [this] contains [other].
   bool containsAabb3(Aabb3 other) {
-    return min.x < other.min.x &&
-        min.y < other.min.y &&
-        min.z < other.min.z &&
-        max.x > other.max.x &&
-        max.y > other.max.y &&
-        max.z > other.max.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x < otherMin.x) &&
+        (_min.y < otherMin.y) &&
+        (_min.z < otherMin.z) &&
+        (_max.x > otherMax.x) &&
+        (_max.y > otherMax.y) &&
+        (_max.z > otherMax.z);
   }
 
   /// Return if [this] contains [other].
   bool containsSphere(Sphere other) {
-    final sphereExtends = new Vector3.zero().splat(other.radius);
-    final sphereBox = new Aabb3.minMax(other.center.clone().sub(sphereExtends),
-        other.center.clone().add(sphereExtends));
+    final boxExtends = new Vector3.all(other._radius);
+    final sphereBox = new Aabb3.centerAndHalfExtents(other._center, boxExtends);
 
     return containsAabb3(sphereBox);
   }
 
   /// Return if [this] contains [other].
   bool containsVector3(Vector3 other) {
-    return min.x < other.x &&
-        min.y < other.y &&
-        min.z < other.z &&
-        max.x > other.x &&
-        max.y > other.y &&
-        max.z > other.z;
+    return (_min.x < other.x) &&
+        (_min.y < other.y) &&
+        (_min.z < other.z) &&
+        (_max.x > other.x) &&
+        (_max.y > other.y) &&
+        (_max.z > other.z);
   }
 
   /// Return if [this] contains [other].
-  bool containsTriangle(Triangle other) {
-    return containsVector3(other.point0) &&
-        containsVector3(other.point1) &&
-        containsVector3(other.point2);
-  }
+  bool containsTriangle(Triangle other) => containsVector3(other._point0) &&
+      containsVector3(other._point1) &&
+      containsVector3(other._point2);
 
   /// Return if [this] intersects with [other].
   bool intersectsWithAabb3(Aabb3 other) {
-    return min.x <= other.max.x &&
-        min.y <= other.max.y &&
-        min.z <= other.max.z &&
-        max.x >= other.min.x &&
-        max.y >= other.min.y &&
-        max.z >= other.min.z;
+    final otherMax = other._max;
+    final otherMin = other._min;
+
+    return (_min.x <= otherMax.x) &&
+        (_min.y <= otherMax.y) &&
+        (_min.z <= otherMax.z) &&
+        (_max.x >= otherMin.x) &&
+        (_max.y >= otherMin.y) &&
+        (_max.z >= otherMin.z);
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithSphere(Sphere other) {
-    double d = 0.0;
-    double e = 0.0;
+    final center = other._center;
+    final radius = other._radius;
+    var d = 0.0;
+    var e = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-      if ((e = other.center[i] - min[i]) < 0.0) {
-        if (e < -other.radius) {
+    for (var i = 0; i < 3; ++i) {
+      if ((e = center[i] - _min[i]) < 0.0) {
+        if (e < -radius) {
           return false;
         }
 
         d = d + e * e;
-      } else if ((e = other.center[i] - max[i]) > 0.0) {
-        if (e > other.radius) {
-          return false;
-        }
+      } else {
+        if ((e = center[i] - _max[i]) > 0.0) {
+          if (e > radius) {
+            return false;
+          }
 
-        d = d + e * e;
+          d = d + e * e;
+        }
       }
     }
 
-    return d <= other.radius * other.radius;
+    return d <= radius * radius;
   }
 
   /// Return if [this] intersects with [other].
   bool intersectsWithVector3(Vector3 other) {
-    return min.x <= other.x &&
-        min.y <= other.y &&
-        min.z <= other.z &&
-        max.x >= other.x &&
-        max.y >= other.y &&
-        max.z >= other.z;
+    return (_min.x <= other.x) &&
+        (_min.y <= other.y) &&
+        (_min.z <= other.z) &&
+        (_max.x >= other.x) &&
+        (_max.y >= other.y) &&
+        (_max.z >= other.z);
   }
 }

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -6,7 +6,7 @@ part of vector_math_64;
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float64List storage = new Float64List(2);
+  final Float64List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -27,28 +27,32 @@ class Vector2 implements Vector {
     result.y = min.y + a * (max.y - min.y);
   }
 
+
+
   /// Construct a new vector with the specified values.
-  Vector2(double x_, double y_) {
-    setValues(x_, y_);
-  }
+  factory Vector2(double x, double y) => new Vector2.zero()..setValues(x, y);
 
   /// Initialized with values from [array] starting at [offset].
-  Vector2.array(List<double> array, [int offset = 0]) {
-    int i = offset;
-    storage[1] = array[i + 1];
-    storage[0] = array[i + 0];
-  }
+  factory Vector2.array(List<double> array, [int offset = 0]) =>
+      new Vector2.zero()..copyFromArray(array, offset);
 
   /// Zero vector.
-  Vector2.zero();
+  Vector2.zero()
+      : storage = new Float64List(2);
 
   /// Splat [value] into all lanes of the vector.
-  Vector2.all(double value) : this(value, value);
+  factory Vector2.all(double value) => new Vector2.zero()..splat(value);
 
   /// Copy of [other].
-  Vector2.copy(Vector2 other) {
-    setFrom(other);
-  }
+  factory Vector2.copy(Vector2 other) => new Vector2.zero()..setFrom(other);
+
+  /// Constructs Vector2 with given Float64List as [storage].
+  Vector2.fromFloat64List(this.storage);
+
+  /// Constructs Vector2 with a [storage] that views given [buffer] starting at
+  /// [offset]. [offset] has to be multiple of [Float64List.BYTES_PER_ELEMENT].
+  Vector2.fromBuffer(ByteBuffer buffer, int offset)
+      : storage = new Float64List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
   Vector2 setValues(double x_, double y_) {

--- a/test/aabb2_test.dart
+++ b/test/aabb2_test.dart
@@ -13,19 +13,48 @@ import 'package:vector_math/vector_math.dart';
 import 'test_utils.dart';
 
 void testAabb2Center() {
-  final Aabb2 aabb = new Aabb2.minMax($v2(1.0, 2.0), $v2(8.0, 16.0));
-  final Vector2 center = aabb.center;
+  final aabb = new Aabb2.minMax($v2(1.0, 2.0), $v2(8.0, 16.0));
+  final center = aabb.center;
 
   expect(center.x, equals(4.5));
   expect(center.y, equals(9.0));
 }
 
+void testAabb2CopyCenterAndHalfExtents() {
+  final a1 = new Aabb2.minMax($v2(10.0, 20.0), $v2(20.0, 40.0));
+  final a2 = new Aabb2.minMax($v2(-10.0, -20.0), $v2(0.0, 0.0));
+
+  final center = new Vector2.zero();
+  final halfExtents = new Vector2.zero();
+
+  a1.copyCenterAndHalfExtents(center, halfExtents);
+
+  relativeTest(center, $v2(15.0, 30.0));
+  relativeTest(halfExtents, $v2(5.0, 10.0));
+
+  a2.copyCenterAndHalfExtents(center, halfExtents);
+
+  relativeTest(center, $v2(-5.0, -10.0));
+  relativeTest(halfExtents, $v2(5.0, 10.0));
+}
+
+void testAabb2setCenterAndHalfExtents() {
+  final a1 = new Aabb2.centerAndHalfExtents($v2(0.0, 0.0), $v2(10.0, 20.0));
+  final a2 = new Aabb2.centerAndHalfExtents($v2(-10.0, -20.0), $v2(10.0, 20.0));
+
+  relativeTest(a1.min, $v2(-10.0, -20.0));
+  relativeTest(a1.max, $v2(10.0, 20.0));
+
+  relativeTest(a2.min, $v2(-20.0, -40.0));
+  relativeTest(a2.max, $v2(0.0, 0.0));
+}
+
 void testAabb2ContainsAabb2() {
-  final Aabb2 parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
-  final Aabb2 child = new Aabb2.minMax($v2(2.0, 2.0), $v2(7.0, 7.0));
-  final Aabb2 cutting = new Aabb2.minMax($v2(0.0, 0.0), $v2(5.0, 5.0));
-  final Aabb2 outside = new Aabb2.minMax($v2(10.0, 10.0), $v2(20.0, 20.0));
-  final Aabb2 grandParent = new Aabb2.minMax($v2(0.0, 0.0), $v2(10.0, 10.0));
+  final parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
+  final child = new Aabb2.minMax($v2(2.0, 2.0), $v2(7.0, 7.0));
+  final cutting = new Aabb2.minMax($v2(0.0, 0.0), $v2(5.0, 5.0));
+  final outside = new Aabb2.minMax($v2(10.0, 10.0), $v2(20.0, 20.0));
+  final grandParent = new Aabb2.minMax($v2(0.0, 0.0), $v2(10.0, 10.0));
 
   expect(parent.containsAabb2(child), isTrue);
   expect(parent.containsAabb2(parent), isFalse);
@@ -35,10 +64,10 @@ void testAabb2ContainsAabb2() {
 }
 
 void testAabb2ContainsVector2() {
-  final Aabb2 parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
-  final Vector2 child = $v2(2.0, 2.0);
-  final Vector2 cutting = $v2(1.0, 8.0);
-  final Vector2 outside = $v2(-1.0, 0.0);
+  final parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
+  final child = $v2(2.0, 2.0);
+  final cutting = $v2(1.0, 8.0);
+  final outside = $v2(-1.0, 0.0);
 
   expect(parent.containsVector2(child), isTrue);
   expect(parent.containsVector2(cutting), isFalse);
@@ -46,15 +75,15 @@ void testAabb2ContainsVector2() {
 }
 
 void testAabb2IntersectionAabb2() {
-  final Aabb2 parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
-  final Aabb2 child = new Aabb2.minMax($v2(2.0, 2.0), $v2(7.0, 7.0));
-  final Aabb2 cutting = new Aabb2.minMax($v2(0.0, 0.0), $v2(5.0, 5.0));
-  final Aabb2 outside = new Aabb2.minMax($v2(10.0, 10.0), $v2(20.0, 20.0));
-  final Aabb2 grandParent = new Aabb2.minMax($v2(0.0, 0.0), $v2(10.0, 10.0));
+  final parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
+  final child = new Aabb2.minMax($v2(2.0, 2.0), $v2(7.0, 7.0));
+  final cutting = new Aabb2.minMax($v2(0.0, 0.0), $v2(5.0, 5.0));
+  final outside = new Aabb2.minMax($v2(10.0, 10.0), $v2(20.0, 20.0));
+  final grandParent = new Aabb2.minMax($v2(0.0, 0.0), $v2(10.0, 10.0));
 
-  final Aabb2 siblingOne = new Aabb2.minMax($v2(0.0, 0.0), $v2(3.0, 3.0));
-  final Aabb2 siblingTwo = new Aabb2.minMax($v2(3.0, 0.0), $v2(6.0, 3.0));
-  final Aabb2 siblingThree = new Aabb2.minMax($v2(3.0, 3.0), $v2(6.0, 6.0));
+  final siblingOne = new Aabb2.minMax($v2(0.0, 0.0), $v2(3.0, 3.0));
+  final siblingTwo = new Aabb2.minMax($v2(3.0, 0.0), $v2(6.0, 3.0));
+  final siblingThree = new Aabb2.minMax($v2(3.0, 3.0), $v2(6.0, 6.0));
 
   expect(parent.intersectsWithAabb2(child), isTrue);
   expect(child.intersectsWithAabb2(parent), isTrue);
@@ -77,10 +106,10 @@ void testAabb2IntersectionAabb2() {
 }
 
 void testAabb2IntersectionVector2() {
-  final Aabb2 parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
-  final Vector2 child = $v2(2.0, 2.0);
-  final Vector2 cutting = $v2(1.0, 8.0);
-  final Vector2 outside = $v2(-1.0, 0.0);
+  final parent = new Aabb2.minMax($v2(1.0, 1.0), $v2(8.0, 8.0));
+  final child = $v2(2.0, 2.0);
+  final cutting = $v2(1.0, 8.0);
+  final outside = $v2(-1.0, 0.0);
 
   expect(parent.intersectsWithVector2(child), isTrue);
   expect(parent.intersectsWithVector2(cutting), isTrue);
@@ -88,8 +117,8 @@ void testAabb2IntersectionVector2() {
 }
 
 void testAabb2Hull() {
-  final Aabb2 a = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 4.0));
-  final Aabb2 b = new Aabb2.minMax($v2(3.0, 2.0), $v2(6.0, 2.0));
+  final a = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 4.0));
+  final b = new Aabb2.minMax($v2(3.0, 2.0), $v2(6.0, 2.0));
 
   a.hull(b);
 
@@ -100,8 +129,8 @@ void testAabb2Hull() {
 }
 
 void testAabb2HullPoint() {
-  final Aabb2 a = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 4.0));
-  final Vector2 b = $v2(6.0, 2.0);
+  final a = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 4.0));
+  final b = $v2(6.0, 2.0);
 
   a.hullPoint(b);
 
@@ -121,10 +150,10 @@ void testAabb2HullPoint() {
 }
 
 void testAabb2Rotate() {
-  final Matrix3 rotation = new Matrix3.rotationZ(Math.PI / 4);
-  final Aabb2 input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
+  final rotation = new Matrix3.rotationZ(Math.PI / 4);
+  final input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
 
-  final Aabb2 result = input.rotate(rotation);
+  final result = input.rotate(rotation);
 
   relativeTest(result.min.x, 2 - Math.sqrt(2));
   relativeTest(result.min.y, 2 - Math.sqrt(2));
@@ -135,11 +164,11 @@ void testAabb2Rotate() {
 }
 
 void testAabb2Transform() {
-  final Matrix3 rotation = new Matrix3.rotationZ(Math.PI / 4);
-  final Aabb2 input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
+  final rotation = new Matrix3.rotationZ(Math.PI / 4);
+  final input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
 
-  final Aabb2 result = input.transform(rotation);
-  final double newCenterY = Math.sqrt(8);
+  final result = input.transform(rotation);
+  final newCenterY = Math.sqrt(8);
 
   relativeTest(result.min.x, -Math.sqrt(2));
   relativeTest(result.min.y, newCenterY - Math.sqrt(2));
@@ -152,6 +181,8 @@ void testAabb2Transform() {
 void main() {
   group('Aabb2', () {
     test('Center', testAabb2Center);
+    test('copyCenterAndHalfExtents', testAabb2CopyCenterAndHalfExtents);
+    test('copyCenterAndHalfExtents', testAabb2setCenterAndHalfExtents);
     test('Contains Aabb2', testAabb2ContainsAabb2);
     test('Contains Vector2', testAabb2ContainsVector2);
     test('Intersection Aabb2', testAabb2IntersectionAabb2);

--- a/test/aabb3_test.dart
+++ b/test/aabb3_test.dart
@@ -13,10 +13,10 @@ import 'package:vector_math/vector_math.dart';
 import 'test_utils.dart';
 
 void testAabb3ByteBufferInstanciation() {
-  final ByteBuffer buffer =
+  final buffer =
       new Float32List.fromList([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]).buffer;
-  final Aabb3 aabb = new Aabb3.fromBuffer(buffer, 0);
-  final Aabb3 aabbOffest =
+  final aabb = new Aabb3.fromBuffer(buffer, 0);
+  final aabbOffest =
       new Aabb3.fromBuffer(buffer, Float32List.BYTES_PER_ELEMENT);
 
   expect(aabb.min.x, equals(1.0));
@@ -35,22 +35,90 @@ void testAabb3ByteBufferInstanciation() {
 }
 
 void testAabb3Center() {
-  final Aabb3 aabb = new Aabb3.minMax($v3(1.0, 2.0, 4.0), $v3(8.0, 16.0, 32.0));
-  final Vector3 center = aabb.center;
+  final aabb = new Aabb3.minMax($v3(1.0, 2.0, 4.0), $v3(8.0, 16.0, 32.0));
+  final center = aabb.center;
 
   expect(center.x, equals(4.5));
   expect(center.y, equals(9.0));
   expect(center.z, equals(18.0));
 }
 
+void testAabb3CopyCenterAndHalfExtents() {
+  final a1 = new Aabb3.minMax($v3(10.0, 20.0, 30.0), $v3(20.0, 40.0, 60.0));
+  final a2 = new Aabb3.minMax($v3(-10.0, -20.0, -30.0), $v3(0.0, 0.0, 0.0));
+
+  final center = new Vector3.zero();
+  final halfExtents = new Vector3.zero();
+
+  a1.copyCenterAndHalfExtents(center, halfExtents);
+
+  relativeTest(center, $v3(15.0, 30.0, 45.0));
+  relativeTest(halfExtents, $v3(5.0, 10.0, 15.0));
+
+  a2.copyCenterAndHalfExtents(center, halfExtents);
+
+  relativeTest(center, $v3(-5.0, -10.0, -15.0));
+  relativeTest(halfExtents, $v3(5.0, 10.0, 15.0));
+}
+
+void testAabb3setCenterAndHalfExtents() {
+  final a1 =
+      new Aabb3.centerAndHalfExtents($v3(0.0, 0.0, 0.0), $v3(10.0, 20.0, 30.0));
+  final a2 = new Aabb3.centerAndHalfExtents(
+      $v3(-10.0, -20.0, -30.0), $v3(10.0, 20.0, 30.0));
+
+  relativeTest(a1.min, $v3(-10.0, -20.0, -30.0));
+  relativeTest(a1.max, $v3(10.0, 20.0, 30.0));
+
+  relativeTest(a2.min, $v3(-20.0, -40.0, -60.0));
+  relativeTest(a2.max, $v3(0.0, 0.0, 0.0));
+}
+
+void testAabb3setSphere() {
+  final s = new Sphere.centerRadius($v3(10.0, 20.0, 30.0), 10.0);
+  final a = new Aabb3.fromSphere(s);
+
+  expect(a.intersectsWithVector3(a.center), isTrue);
+  expect(a.intersectsWithVector3($v3(20.0, 20.0, 30.0)), isTrue);
+}
+
+void testAabb3setRay() {
+  final r = new Ray.originDirection(
+      $v3(1.0, 2.0, 3.0), $v3(1.0, 5.0, -1.0)..normalize());
+  final a = new Aabb3.fromRay(r, 0.0, 10.0);
+
+  expect(a.intersectsWithVector3(r.at(0.0)), isTrue);
+  expect(a.intersectsWithVector3(r.at(10.0)), isTrue);
+}
+
+void testAabb3setTriangle() {
+  final t = new Triangle.points(
+      $v3(2.0, 0.0, 0.0), $v3(0.0, 2.0, 0.0), $v3(0.0, 0.0, 2.0));
+  final a = new Aabb3.fromTriangle(t);
+
+  expect(a.intersectsWithVector3(t.point0), isTrue);
+  expect(a.intersectsWithVector3(t.point1), isTrue);
+  expect(a.intersectsWithVector3(t.point2), isTrue);
+}
+
+void testAabb3setQuad() {
+  final q = new Quad.points($v3(2.0, 0.0, 0.0), $v3(0.0, 2.0, 0.0),
+      $v3(0.0, 0.0, 2.0), $v3(0.0, 0.0, -2.0));
+  final a = new Aabb3.fromQuad(q);
+
+  expect(a.intersectsWithVector3(q.point0), isTrue);
+  expect(a.intersectsWithVector3(q.point1), isTrue);
+  expect(a.intersectsWithVector3(q.point2), isTrue);
+  expect(a.intersectsWithVector3(q.point3), isTrue);
+}
+
 void testAabb3ContainsAabb3() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Aabb3 child = new Aabb3.minMax($v3(2.0, 2.0, 2.0), $v3(7.0, 7.0, 7.0));
-  final Aabb3 cutting =
-      new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(5.0, 5.0, 5.0));
-  final Aabb3 outside =
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Aabb3.minMax($v3(2.0, 2.0, 2.0), $v3(7.0, 7.0, 7.0));
+  final cutting = new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(5.0, 5.0, 5.0));
+  final outside =
       new Aabb3.minMax($v3(10.0, 10.0, 10.0), $v3(20.0, 20.0, 20.0));
-  final Aabb3 grandParent =
+  final grandParent =
       new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(10.0, 10.0, 10.0));
 
   expect(parent.containsAabb3(child), isTrue);
@@ -61,10 +129,10 @@ void testAabb3ContainsAabb3() {
 }
 
 void testAabb3ContainsSphere() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Sphere child = new Sphere.centerRadius($v3(3.0, 3.0, 3.0), 1.5);
-  final Sphere cutting = new Sphere.centerRadius($v3(0.0, 0.0, 0.0), 6.0);
-  final Sphere outside = new Sphere.centerRadius($v3(-10.0, -10.0, -10.0), 5.0);
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Sphere.centerRadius($v3(3.0, 3.0, 3.0), 1.5);
+  final cutting = new Sphere.centerRadius($v3(0.0, 0.0, 0.0), 6.0);
+  final outside = new Sphere.centerRadius($v3(-10.0, -10.0, -10.0), 5.0);
 
   expect(parent.containsSphere(child), isTrue);
   expect(parent.containsSphere(cutting), isFalse);
@@ -72,10 +140,10 @@ void testAabb3ContainsSphere() {
 }
 
 void testAabb3ContainsVector3() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Vector3 child = $v3(7.0, 7.0, 7.0);
-  final Vector3 cutting = $v3(1.0, 2.0, 1.0);
-  final Vector3 outside = $v3(-10.0, 10.0, 10.0);
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = $v3(7.0, 7.0, 7.0);
+  final cutting = $v3(1.0, 2.0, 1.0);
+  final outside = $v3(-10.0, 10.0, 10.0);
 
   expect(parent.containsVector3(child), isTrue);
   expect(parent.containsVector3(cutting), isFalse);
@@ -83,14 +151,14 @@ void testAabb3ContainsVector3() {
 }
 
 void testAabb3ContainsTriangle() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Triangle child = new Triangle.points(
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Triangle.points(
       $v3(2.0, 2.0, 2.0), $v3(3.0, 3.0, 3.0), $v3(4.0, 4.0, 4.0));
-  final Triangle edge = new Triangle.points(
+  final edge = new Triangle.points(
       $v3(1.0, 1.0, 1.0), $v3(3.0, 3.0, 3.0), $v3(4.0, 4.0, 4.0));
-  final Triangle cutting = new Triangle.points(
+  final cutting = new Triangle.points(
       $v3(2.0, 2.0, 2.0), $v3(3.0, 3.0, 3.0), $v3(14.0, 14.0, 14.0));
-  final Triangle outside = new Triangle.points(
+  final outside = new Triangle.points(
       $v3(0.0, 0.0, 0.0), $v3(-3.0, -3.0, -3.0), $v3(-4.0, -4.0, -4.0));
 
   expect(parent.containsTriangle(child), isTrue);
@@ -100,21 +168,17 @@ void testAabb3ContainsTriangle() {
 }
 
 void testAabb3IntersectionAabb3() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Aabb3 child = new Aabb3.minMax($v3(2.0, 2.0, 2.0), $v3(7.0, 7.0, 7.0));
-  final Aabb3 cutting =
-      new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(5.0, 5.0, 5.0));
-  final Aabb3 outside =
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Aabb3.minMax($v3(2.0, 2.0, 2.0), $v3(7.0, 7.0, 7.0));
+  final cutting = new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(5.0, 5.0, 5.0));
+  final outside =
       new Aabb3.minMax($v3(10.0, 10.0, 10.0), $v3(20.0, 20.0, 10.0));
-  final Aabb3 grandParent =
+  final grandParent =
       new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(10.0, 10.0, 10.0));
 
-  final Aabb3 siblingOne =
-      new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(3.0, 3.0, 3.0));
-  final Aabb3 siblingTwo =
-      new Aabb3.minMax($v3(3.0, 0.0, 0.0), $v3(6.0, 3.0, 3.0));
-  final Aabb3 siblingThree =
-      new Aabb3.minMax($v3(3.0, 3.0, 3.0), $v3(6.0, 6.0, 6.0));
+  final siblingOne = new Aabb3.minMax($v3(0.0, 0.0, 0.0), $v3(3.0, 3.0, 3.0));
+  final siblingTwo = new Aabb3.minMax($v3(3.0, 0.0, 0.0), $v3(6.0, 3.0, 3.0));
+  final siblingThree = new Aabb3.minMax($v3(3.0, 3.0, 3.0), $v3(6.0, 6.0, 6.0));
 
   expect(parent.intersectsWithAabb3(child), isTrue);
   expect(child.intersectsWithAabb3(parent), isTrue);
@@ -137,10 +201,10 @@ void testAabb3IntersectionAabb3() {
 }
 
 void testAabb3IntersectionSphere() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Sphere child = new Sphere.centerRadius($v3(3.0, 3.0, 3.0), 1.5);
-  final Sphere cutting = new Sphere.centerRadius($v3(0.0, 0.0, 0.0), 6.0);
-  final Sphere outside = new Sphere.centerRadius($v3(-10.0, -10.0, -10.0), 5.0);
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Sphere.centerRadius($v3(3.0, 3.0, 3.0), 1.5);
+  final cutting = new Sphere.centerRadius($v3(0.0, 0.0, 0.0), 6.0);
+  final outside = new Sphere.centerRadius($v3(-10.0, -10.0, -10.0), 5.0);
 
   expect(parent.intersectsWithSphere(child), isTrue);
   expect(parent.intersectsWithSphere(cutting), isTrue);
@@ -148,10 +212,10 @@ void testAabb3IntersectionSphere() {
 }
 
 void testAabb3IntersectionVector3() {
-  final Aabb3 parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
-  final Vector3 child = $v3(7.0, 7.0, 7.0);
-  final Vector3 cutting = $v3(1.0, 2.0, 1.0);
-  final Vector3 outside = $v3(-10.0, 10.0, 10.0);
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = $v3(7.0, 7.0, 7.0);
+  final cutting = $v3(1.0, 2.0, 1.0);
+  final outside = $v3(-10.0, 10.0, 10.0);
 
   expect(parent.intersectsWithVector3(child), isTrue);
   expect(parent.intersectsWithVector3(cutting), isTrue);
@@ -159,8 +223,8 @@ void testAabb3IntersectionVector3() {
 }
 
 void testAabb3Hull() {
-  final Aabb3 a = new Aabb3.minMax($v3(1.0, 1.0, 4.0), $v3(3.0, 4.0, 10.0));
-  final Aabb3 b = new Aabb3.minMax($v3(3.0, 2.0, 3.0), $v3(6.0, 2.0, 8.0));
+  final a = new Aabb3.minMax($v3(1.0, 1.0, 4.0), $v3(3.0, 4.0, 10.0));
+  final b = new Aabb3.minMax($v3(3.0, 2.0, 3.0), $v3(6.0, 2.0, 8.0));
 
   a.hull(b);
 
@@ -173,8 +237,8 @@ void testAabb3Hull() {
 }
 
 void testAabb3HullPoint() {
-  final Aabb3 a = new Aabb3.minMax($v3(1.0, 1.0, 4.0), $v3(3.0, 4.0, 10.0));
-  final Vector3 b = $v3(6.0, 2.0, 8.0);
+  final a = new Aabb3.minMax($v3(1.0, 1.0, 4.0), $v3(3.0, 4.0, 10.0));
+  final b = $v3(6.0, 2.0, 8.0);
 
   a.hullPoint(b);
 
@@ -201,6 +265,12 @@ void main() {
   group('Aabb3', () {
     test('ByteBuffer instanciation', testAabb3ByteBufferInstanciation);
     test('Center', testAabb3Center);
+    test('copyCenterAndHalfExtents', testAabb3CopyCenterAndHalfExtents);
+    test('copyCenterAndHalfExtents', testAabb3setCenterAndHalfExtents);
+    test('setSphere', testAabb3setSphere);
+    test('setRay', testAabb3setRay);
+    test('setTriangle', testAabb3setTriangle);
+    test('setQuad', testAabb3setQuad);
     test('Contains Aabb3', testAabb3ContainsAabb3);
     test('Contains Vector3', testAabb3ContainsVector3);
     test('Contains Triangle', testAabb3ContainsTriangle);


### PR DESCRIPTION
* Add more constructors / setters to create a Aabb from another volumes (e.g. spheres).
* Remove type annotations in aabb tests, they only make reading them hard
* Add the corresponding tests

The code already contains some future changes Vector2 as the PR depends on them. The next PR will take a focus on Vector2.