### PR TITLE
Cleanup Vector2

### DIFF
--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -6,7 +6,7 @@ part of vector_math;
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float32List storage;
+  final Float32List _storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -20,14 +20,15 @@ class Vector2 implements Vector {
     result.y = Math.max(a.y, b.y);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear
-  // interpolation and set the values to [result].
+  /// Interpolate between [min] and [max] with the amount of [a] using a linear
+  /// interpolation and store the values in [result].
   static void mix(Vector2 min, Vector2 max, double a, Vector2 result) {
     result.x = min.x + a * (max.x - min.x);
     result.y = min.y + a * (max.y - min.y);
   }
 
-
+  /// The components of the vector.
+  Float32List get storage => _storage;
 
   /// Construct a new vector with the specified values.
   factory Vector2(double x, double y) => new Vector2.zero()..setValues(x, y);
@@ -37,8 +38,7 @@ class Vector2 implements Vector {
       new Vector2.zero()..copyFromArray(array, offset);
 
   /// Zero vector.
-  Vector2.zero()
-      : storage = new Float32List(2);
+  Vector2.zero() : _storage = new Float32List(2);
 
   /// Splat [value] into all lanes of the vector.
   factory Vector2.all(double value) => new Vector2.zero()..splat(value);
@@ -46,87 +46,77 @@ class Vector2 implements Vector {
   /// Copy of [other].
   factory Vector2.copy(Vector2 other) => new Vector2.zero()..setFrom(other);
 
-  /// Constructs Vector2 with given Float32List as [storage].
-  Vector2.fromFloat32List(this.storage);
+  /// Constructs Vector2 with a given [Float32List] as [storage].
+  Vector2.fromFloat32List(this._storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
   /// [offset]. [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : storage = new Float32List.view(buffer, offset, 2);
+      : _storage = new Float32List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
   Vector2 setValues(double x_, double y_) {
-    storage[0] = x_;
-    storage[1] = y_;
+    _storage[0] = x_;
+    _storage[1] = y_;
     return this;
   }
 
   /// Zero the vector.
   Vector2 setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
     return this;
   }
 
   /// Set the values by copying them from [other].
   Vector2 setFrom(Vector2 other) {
-    storage[1] = other.storage[1];
-    storage[0] = other.storage[0];
+    final otherStorage = other._storage;
+    _storage[1] = otherStorage[1];
+    _storage[0] = otherStorage[0];
     return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
   Vector2 splat(double arg) {
-    storage[0] = arg;
-    storage[1] = arg;
+    _storage[0] = arg;
+    _storage[1] = arg;
     return this;
   }
 
   /// Returns a printable string
-  String toString() => '[${storage[0]},${storage[1]}]';
+  String toString() => '[${_storage[0]},${_storage[1]}]';
 
   /// Negate.
-  Vector2 operator -() => new Vector2(-storage[0], -storage[1]);
+  Vector2 operator -() => clone()..negate();
 
   /// Subtract two vectors.
-  Vector2 operator -(Vector2 other) =>
-      new Vector2(storage[0] - other.storage[0], storage[1] - other.storage[1]);
+  Vector2 operator -(Vector2 other) => clone()..sub(other);
 
   /// Add two vectors.
-  Vector2 operator +(Vector2 other) =>
-      new Vector2(storage[0] + other.storage[0], storage[1] + other.storage[1]);
+  Vector2 operator +(Vector2 other) => clone()..add(other);
 
   /// Scale.
-  Vector2 operator /(double scale) {
-    var o = 1.0 / scale;
-    return new Vector2(storage[0] * o, storage[1] * o);
-  }
+  Vector2 operator /(double scale) => clone()..scale(1.0 / scale);
 
   /// Scale.
-  Vector2 operator *(double scale) {
-    var o = scale;
-    return new Vector2(storage[0] * o, storage[1] * o);
-  }
+  Vector2 operator *(double scale) => clone()..scale(scale);
 
-  double operator [](int i) => storage[i];
+  /// Access the component of the vector at the index [i].
+  double operator [](int i) => _storage[i];
 
+  /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    storage[i] = v;
+    _storage[i] = v;
   }
 
   /// Length.
-  double get length {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    return Math.sqrt(sum);
-  }
+  double get length => Math.sqrt(length2);
 
   /// Length squared.
   double get length2 {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
+    var sum;
+    sum = (_storage[0] * _storage[0]);
+    sum += (_storage[1] * _storage[1]);
     return sum;
   }
 
@@ -138,8 +128,8 @@ class Vector2 implements Vector {
       return this;
     }
     l = 1.0 / l;
-    storage[0] *= l;
-    storage[1] *= l;
+    _storage[0] *= l;
+    _storage[1] *= l;
     return this;
   }
 
@@ -150,15 +140,13 @@ class Vector2 implements Vector {
       return 0.0;
     }
     var d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
+    _storage[0] *= d;
+    _storage[1] *= d;
     return l;
   }
 
   /// Normalized copy of [this].
-  Vector2 normalized() {
-    return new Vector2.copy(this).normalize();
-  }
+  Vector2 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector2 normalizeInto(Vector2 out) {
@@ -179,9 +167,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
+    final otherStorage = other._storage;
     double sum;
-    sum = storage[0] * other.storage[0];
-    sum += storage[1] * other.storage[1];
+    sum = _storage[0] * otherStorage[0];
+    sum += _storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -192,35 +181,35 @@ class Vector2 implements Vector {
    * the inverse of the transformation.
    */
   Vector2 postmultiply(Matrix2 arg) {
-    double v0 = storage[0];
-    double v1 = storage[1];
-    storage[0] = v0 * arg.storage[0] + v1 * arg.storage[1];
-    storage[1] = v0 * arg.storage[2] + v1 * arg.storage[3];
+    final argStorage = arg.storage;
+    double v0 = _storage[0];
+    double v1 = _storage[1];
+    _storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    _storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
 
     return this;
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    return storage[0] * other.storage[1] - storage[1] * other.storage[0];
+    final otherStorage = other._storage;
+    return _storage[0] * otherStorage[1] - _storage[1] * otherStorage[0];
   }
 
   /// Rotate [this] by 90 degrees then scale it. Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * storage[1], scale * storage[0]);
+    out.setValues(-scale * _storage[1], scale * _storage[0]);
     return out;
   }
 
   /// Reflect [this].
   Vector2 reflect(Vector2 normal) {
-    sub(normal.scaled(2 * normal.dot(this)));
+    sub(normal.scaled(2.0 * normal.dot(this)));
     return this;
   }
 
   /// Reflected copy of [this].
-  Vector2 reflected(Vector2 normal) {
-    return new Vector2.copy(this).reflect(normal);
-  }
+  Vector2 reflected(Vector2 normal) => clone()..reflect(normal);
 
   /// Relative error between [this] and [correct]
   double relativeError(Vector2 correct) {
@@ -237,311 +226,276 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     bool is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
+    is_infinite = is_infinite || _storage[0].isInfinite;
+    is_infinite = is_infinite || _storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     bool is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
+    is_nan = is_nan || _storage[0].isNaN;
+    is_nan = is_nan || _storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to [this].
   Vector2 add(Vector2 arg) {
-    storage[0] = storage[0] + arg.storage[0];
-    storage[1] = storage[1] + arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0];
+    _storage[1] = _storage[1] + argStorage[1];
     return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
   Vector2 addScaled(Vector2 arg, double factor) {
-    storage[0] = storage[0] + arg.storage[0] * factor;
-    storage[1] = storage[1] + arg.storage[1] * factor;
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0] * factor;
+    _storage[1] = _storage[1] + argStorage[1] * factor;
     return this;
   }
 
   /// Subtract [arg] from [this].
   Vector2 sub(Vector2 arg) {
-    storage[0] = storage[0] - arg.storage[0];
-    storage[1] = storage[1] - arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] - argStorage[0];
+    _storage[1] = _storage[1] - argStorage[1];
     return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
   Vector2 multiply(Vector2 arg) {
-    storage[0] = storage[0] * arg.storage[0];
-    storage[1] = storage[1] * arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] * argStorage[0];
+    _storage[1] = _storage[1] * argStorage[1];
     return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
   Vector2 divide(Vector2 arg) {
-    storage[0] = storage[0] / arg.storage[0];
-    storage[1] = storage[1] / arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] / argStorage[0];
+    _storage[1] = _storage[1] / argStorage[1];
     return this;
   }
 
-  /// Scale [this].
+  /// Scale [this] by [arg].
   Vector2 scale(double arg) {
-    storage[1] = storage[1] * arg;
-    storage[0] = storage[0] * arg;
+    _storage[1] = _storage[1] * arg;
+    _storage[0] = _storage[0] * arg;
     return this;
   }
 
-  Vector2 scaled(double arg) {
-    return clone().scale(arg);
-  }
+  /// Return a copy of [this] scaled by [arg].
+  Vector2 scaled(double arg) => clone()..scale(arg);
 
   /// Negate.
   Vector2 negate() {
-    storage[1] = -storage[1];
-    storage[0] = -storage[0];
+    _storage[1] = -_storage[1];
+    _storage[0] = -_storage[0];
     return this;
   }
 
   /// Absolute value.
   Vector2 absolute() {
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    _storage[1] = _storage[1].abs();
+    _storage[0] = _storage[0].abs();
     return this;
   }
-  
+
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
   Vector2 clamp(Vector2 min, Vector2 max) {
-    storage[0] = storage[0].clamp(min.storage[0], max.storage[0]);
-    storage[1] = storage[1].clamp(min.storage[1], max.storage[1]);
+    _storage[0] = _storage[0].clamp(min.storage[0], max.storage[0]);
+    _storage[1] = _storage[1].clamp(min.storage[1], max.storage[1]);
     return this;
   }
-  
+
   /// Clamp entries [this] in the range [min]-[max].
   Vector2 clampScalar(double min, double max) {
-    storage[0] = storage[0].clamp(min, max);
-    storage[1] = storage[1].clamp(min, max);
+    _storage[0] = _storage[0].clamp(min, max);
+    _storage[1] = _storage[1].clamp(min, max);
     return this;
   }
-  
+
   /// Floor entries in [this].
   Vector2 floor() {
-    storage[0] = storage[0].floorToDouble();
-    storage[1] = storage[1].floorToDouble();
+    _storage[0] = _storage[0].floorToDouble();
+    _storage[1] = _storage[1].floorToDouble();
     return this;
   }
-  
+
   /// Ceil entries in [this].
   Vector2 ceil() {
-    storage[0] = storage[0].ceilToDouble();
-    storage[1] = storage[1].ceilToDouble();
+    _storage[0] = _storage[0].ceilToDouble();
+    _storage[1] = _storage[1].ceilToDouble();
     return this;
   }
-  
+
   /// Round entries in [this].
   Vector2 round() {
-    storage[0] = storage[0].roundToDouble();
-    storage[1] = storage[1].roundToDouble();
+    _storage[0] = _storage[0].roundToDouble();
+    _storage[1] = _storage[1].roundToDouble();
     return this;
   }
-  
+
   /// Round entries in [this] towards zero.
   Vector2 roundToZero() {
-    storage[0] = storage[0] < 0.0 ? storage[0].ceilToDouble() : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0 ? storage[1].ceilToDouble() : storage[1].floorToDouble();
+    _storage[0] = _storage[0] < 0.0
+        ? _storage[0].ceilToDouble()
+        : _storage[0].floorToDouble();
+    _storage[1] = _storage[1] < 0.0
+        ? _storage[1].ceilToDouble()
+        : _storage[1].floorToDouble();
     return this;
   }
 
   /// Clone of [this].
-  Vector2 clone() {
-    return new Vector2.copy(this);
-  }
+  Vector2 clone() => new Vector2.copy(this);
 
   /// Copy [this] into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    arg.storage[1] = storage[1];
-    arg.storage[0] = storage[0];
+    final argStorage = arg._storage;
+    argStorage[1] = _storage[1];
+    argStorage[0] = _storage[0];
     return arg;
   }
 
   /// Copies [this] into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = storage[1];
-    array[offset + 0] = storage[0];
+    array[offset + 1] = _storage[1];
+    array[offset + 0] = _storage[0];
   }
 
   /// Copies elements from [array] into [this] starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[1] = array[offset + 1];
-    storage[0] = array[offset + 0];
+    _storage[1] = array[offset + 1];
+    _storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set yx(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
-  set r(double arg) => storage[0] = arg;
-  set g(double arg) => storage[1] = arg;
-  set s(double arg) => storage[0] = arg;
-  set t(double arg) => storage[1] = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
-  set rg(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set gr(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set st(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ts(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  Vector2 get xx => new Vector2(storage[0], storage[0]);
-  Vector2 get xy => new Vector2(storage[0], storage[1]);
-  Vector2 get yx => new Vector2(storage[1], storage[0]);
-  Vector2 get yy => new Vector2(storage[1], storage[1]);
-  Vector3 get xxx => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xyx => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get yxx => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yyx => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => new Vector3(storage[1], storage[1], storage[1]);
+  set r(double arg) => x = arg;
+  set g(double arg) => y = arg;
+  set s(double arg) => x = arg;
+  set t(double arg) => y = arg;
+  set x(double arg) => _storage[0] = arg;
+  set y(double arg) => _storage[1] = arg;
+  set rg(Vector2 arg) => xy = arg;
+  set gr(Vector2 arg) => yx = arg;
+  set st(Vector2 arg) => xy = arg;
+  set ts(Vector2 arg) => yx = arg;
+  Vector2 get xx => new Vector2(_storage[0], _storage[0]);
+  Vector2 get xy => new Vector2(_storage[0], _storage[1]);
+  Vector2 get yx => new Vector2(_storage[1], _storage[0]);
+  Vector2 get yy => new Vector2(_storage[1], _storage[1]);
+  Vector3 get xxx => new Vector3(_storage[0], _storage[0], _storage[0]);
+  Vector3 get xxy => new Vector3(_storage[0], _storage[0], _storage[1]);
+  Vector3 get xyx => new Vector3(_storage[0], _storage[1], _storage[0]);
+  Vector3 get xyy => new Vector3(_storage[0], _storage[1], _storage[1]);
+  Vector3 get yxx => new Vector3(_storage[1], _storage[0], _storage[0]);
+  Vector3 get yxy => new Vector3(_storage[1], _storage[0], _storage[1]);
+  Vector3 get yyx => new Vector3(_storage[1], _storage[1], _storage[0]);
+  Vector3 get yyy => new Vector3(_storage[1], _storage[1], _storage[1]);
   Vector4 get xxxx =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[0]);
   Vector4 get xxxy =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[1]);
   Vector4 get xxyx =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[0]);
   Vector4 get xxyy =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[1]);
   Vector4 get xyxx =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[0]);
   Vector4 get xyxy =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[1]);
   Vector4 get xyyx =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[0]);
   Vector4 get xyyy =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[1]);
   Vector4 get yxxx =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[0]);
   Vector4 get yxxy =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[1]);
   Vector4 get yxyx =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[0]);
   Vector4 get yxyy =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[1]);
   Vector4 get yyxx =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[0]);
   Vector4 get yyxy =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[1]);
   Vector4 get yyyx =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[0]);
   Vector4 get yyyy =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  double get r => storage[0];
-  double get g => storage[1];
-  double get s => storage[0];
-  double get t => storage[1];
-  double get x => storage[0];
-  double get y => storage[1];
-  Vector2 get rr => new Vector2(storage[0], storage[0]);
-  Vector2 get rg => new Vector2(storage[0], storage[1]);
-  Vector2 get gr => new Vector2(storage[1], storage[0]);
-  Vector2 get gg => new Vector2(storage[1], storage[1]);
-  Vector3 get rrr => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get rrg => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get rgr => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get rgg => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get grr => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get grg => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get ggr => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ggg => new Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get rrrr =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get rrrg =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get rrgr =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get rrgg =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get rgrr =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get rgrg =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get rggr =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get rggg =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get grrr =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get grrg =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get grgr =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get grgg =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get ggrr =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ggrg =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get gggr =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get gggg =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector2 get ss => new Vector2(storage[0], storage[0]);
-  Vector2 get st => new Vector2(storage[0], storage[1]);
-  Vector2 get ts => new Vector2(storage[1], storage[0]);
-  Vector2 get tt => new Vector2(storage[1], storage[1]);
-  Vector3 get sss => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get sst => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get sts => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get stt => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get tss => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get tst => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get tts => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ttt => new Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get ssss =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get ssst =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get ssts =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get sstt =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get stss =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get stst =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get stts =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get sttt =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get tsss =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get tsst =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get tsts =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get tstt =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get ttss =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ttst =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ttts =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get tttt =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[1]);
+  double get r => x;
+  double get g => y;
+  double get s => x;
+  double get t => y;
+  double get x => _storage[0];
+  double get y => _storage[1];
+  Vector2 get rr => xx;
+  Vector2 get rg => xy;
+  Vector2 get gr => yx;
+  Vector2 get gg => yy;
+  Vector3 get rrr => xxx;
+  Vector3 get rrg => xxy;
+  Vector3 get rgr => xyx;
+  Vector3 get rgg => xyy;
+  Vector3 get grr => yxx;
+  Vector3 get grg => yxy;
+  Vector3 get ggr => yyx;
+  Vector3 get ggg => yyy;
+  Vector4 get rrrr => xxxx;
+  Vector4 get rrrg => xxxy;
+  Vector4 get rrgr => xxyx;
+  Vector4 get rrgg => xxyy;
+  Vector4 get rgrr => xyxx;
+  Vector4 get rgrg => xyxy;
+  Vector4 get rggr => xyyx;
+  Vector4 get rggg => xyyy;
+  Vector4 get grrr => yxxx;
+  Vector4 get grrg => yxxy;
+  Vector4 get grgr => yxyx;
+  Vector4 get grgg => yxyy;
+  Vector4 get ggrr => yyxx;
+  Vector4 get ggrg => yyxy;
+  Vector4 get gggr => yyyx;
+  Vector4 get gggg => yyyy;
+  Vector2 get ss => xx;
+  Vector2 get st => xy;
+  Vector2 get ts => yx;
+  Vector2 get tt => yy;
+  Vector3 get sss => xxx;
+  Vector3 get sst => xxy;
+  Vector3 get sts => xyx;
+  Vector3 get stt => xyy;
+  Vector3 get tss => yxx;
+  Vector3 get tst => yxy;
+  Vector3 get tts => yyx;
+  Vector3 get ttt => yyy;
+  Vector4 get ssss => xxxx;
+  Vector4 get ssst => xxxy;
+  Vector4 get ssts => xxyx;
+  Vector4 get sstt => xxyy;
+  Vector4 get stss => xyxx;
+  Vector4 get stst => xyxy;
+  Vector4 get stts => xyyx;
+  Vector4 get sttt => xyyy;
+  Vector4 get tsss => yxxx;
+  Vector4 get tsst => yxxy;
+  Vector4 get tsts => yxyx;
+  Vector4 get tstt => yxyy;
+  Vector4 get ttss => yyxx;
+  Vector4 get ttst => yyxy;
+  Vector4 get ttts => yyyx;
+  Vector4 get tttt => yyyy;
 }

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -6,7 +6,7 @@ part of vector_math_64;
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float64List storage;
+  final Float64List _storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -20,14 +20,15 @@ class Vector2 implements Vector {
     result.y = Math.max(a.y, b.y);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear
-  // interpolation and set the values to [result].
+  /// Interpolate between [min] and [max] with the amount of [a] using a linear
+  /// interpolation and store the values in [result].
   static void mix(Vector2 min, Vector2 max, double a, Vector2 result) {
     result.x = min.x + a * (max.x - min.x);
     result.y = min.y + a * (max.y - min.y);
   }
 
-
+  /// The components of the vector.
+  Float64List get storage => _storage;
 
   /// Construct a new vector with the specified values.
   factory Vector2(double x, double y) => new Vector2.zero()..setValues(x, y);
@@ -37,8 +38,7 @@ class Vector2 implements Vector {
       new Vector2.zero()..copyFromArray(array, offset);
 
   /// Zero vector.
-  Vector2.zero()
-      : storage = new Float64List(2);
+  Vector2.zero() : _storage = new Float64List(2);
 
   /// Splat [value] into all lanes of the vector.
   factory Vector2.all(double value) => new Vector2.zero()..splat(value);
@@ -46,87 +46,77 @@ class Vector2 implements Vector {
   /// Copy of [other].
   factory Vector2.copy(Vector2 other) => new Vector2.zero()..setFrom(other);
 
-  /// Constructs Vector2 with given Float64List as [storage].
-  Vector2.fromFloat64List(this.storage);
+  /// Constructs Vector2 with a given [Float64List] as [storage].
+  Vector2.fromFloat64List(this._storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
   /// [offset]. [offset] has to be multiple of [Float64List.BYTES_PER_ELEMENT].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : storage = new Float64List.view(buffer, offset, 2);
+      : _storage = new Float64List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
   Vector2 setValues(double x_, double y_) {
-    storage[0] = x_;
-    storage[1] = y_;
+    _storage[0] = x_;
+    _storage[1] = y_;
     return this;
   }
 
   /// Zero the vector.
   Vector2 setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
     return this;
   }
 
   /// Set the values by copying them from [other].
   Vector2 setFrom(Vector2 other) {
-    storage[1] = other.storage[1];
-    storage[0] = other.storage[0];
+    final otherStorage = other._storage;
+    _storage[1] = otherStorage[1];
+    _storage[0] = otherStorage[0];
     return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
   Vector2 splat(double arg) {
-    storage[0] = arg;
-    storage[1] = arg;
+    _storage[0] = arg;
+    _storage[1] = arg;
     return this;
   }
 
   /// Returns a printable string
-  String toString() => '[${storage[0]},${storage[1]}]';
+  String toString() => '[${_storage[0]},${_storage[1]}]';
 
   /// Negate.
-  Vector2 operator -() => new Vector2(-storage[0], -storage[1]);
+  Vector2 operator -() => clone()..negate();
 
   /// Subtract two vectors.
-  Vector2 operator -(Vector2 other) =>
-      new Vector2(storage[0] - other.storage[0], storage[1] - other.storage[1]);
+  Vector2 operator -(Vector2 other) => clone()..sub(other);
 
   /// Add two vectors.
-  Vector2 operator +(Vector2 other) =>
-      new Vector2(storage[0] + other.storage[0], storage[1] + other.storage[1]);
+  Vector2 operator +(Vector2 other) => clone()..add(other);
 
   /// Scale.
-  Vector2 operator /(double scale) {
-    var o = 1.0 / scale;
-    return new Vector2(storage[0] * o, storage[1] * o);
-  }
+  Vector2 operator /(double scale) => clone()..scale(1.0 / scale);
 
   /// Scale.
-  Vector2 operator *(double scale) {
-    var o = scale;
-    return new Vector2(storage[0] * o, storage[1] * o);
-  }
+  Vector2 operator *(double scale) => clone()..scale(scale);
 
-  double operator [](int i) => storage[i];
+  /// Access the component of the vector at the index [i].
+  double operator [](int i) => _storage[i];
 
+  /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    storage[i] = v;
+    _storage[i] = v;
   }
 
   /// Length.
-  double get length {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    return Math.sqrt(sum);
-  }
+  double get length => Math.sqrt(length2);
 
   /// Length squared.
   double get length2 {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
+    var sum;
+    sum = (_storage[0] * _storage[0]);
+    sum += (_storage[1] * _storage[1]);
     return sum;
   }
 
@@ -138,8 +128,8 @@ class Vector2 implements Vector {
       return this;
     }
     l = 1.0 / l;
-    storage[0] *= l;
-    storage[1] *= l;
+    _storage[0] *= l;
+    _storage[1] *= l;
     return this;
   }
 
@@ -150,15 +140,13 @@ class Vector2 implements Vector {
       return 0.0;
     }
     var d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
+    _storage[0] *= d;
+    _storage[1] *= d;
     return l;
   }
 
   /// Normalized copy of [this].
-  Vector2 normalized() {
-    return new Vector2.copy(this).normalize();
-  }
+  Vector2 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector2 normalizeInto(Vector2 out) {
@@ -179,9 +167,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
+    final otherStorage = other._storage;
     double sum;
-    sum = storage[0] * other.storage[0];
-    sum += storage[1] * other.storage[1];
+    sum = _storage[0] * otherStorage[0];
+    sum += _storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -192,35 +181,35 @@ class Vector2 implements Vector {
    * the inverse of the transformation.
    */
   Vector2 postmultiply(Matrix2 arg) {
-    double v0 = storage[0];
-    double v1 = storage[1];
-    storage[0] = v0 * arg.storage[0] + v1 * arg.storage[1];
-    storage[1] = v0 * arg.storage[2] + v1 * arg.storage[3];
+    final argStorage = arg.storage;
+    double v0 = _storage[0];
+    double v1 = _storage[1];
+    _storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    _storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
 
     return this;
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    return storage[0] * other.storage[1] - storage[1] * other.storage[0];
+    final otherStorage = other._storage;
+    return _storage[0] * otherStorage[1] - _storage[1] * otherStorage[0];
   }
 
   /// Rotate [this] by 90 degrees then scale it. Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * storage[1], scale * storage[0]);
+    out.setValues(-scale * _storage[1], scale * _storage[0]);
     return out;
   }
 
   /// Reflect [this].
   Vector2 reflect(Vector2 normal) {
-    sub(normal.scaled(2 * normal.dot(this)));
+    sub(normal.scaled(2.0 * normal.dot(this)));
     return this;
   }
 
   /// Reflected copy of [this].
-  Vector2 reflected(Vector2 normal) {
-    return new Vector2.copy(this).reflect(normal);
-  }
+  Vector2 reflected(Vector2 normal) => clone()..reflect(normal);
 
   /// Relative error between [this] and [correct]
   double relativeError(Vector2 correct) {
@@ -237,311 +226,276 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     bool is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
+    is_infinite = is_infinite || _storage[0].isInfinite;
+    is_infinite = is_infinite || _storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     bool is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
+    is_nan = is_nan || _storage[0].isNaN;
+    is_nan = is_nan || _storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to [this].
   Vector2 add(Vector2 arg) {
-    storage[0] = storage[0] + arg.storage[0];
-    storage[1] = storage[1] + arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0];
+    _storage[1] = _storage[1] + argStorage[1];
     return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
   Vector2 addScaled(Vector2 arg, double factor) {
-    storage[0] = storage[0] + arg.storage[0] * factor;
-    storage[1] = storage[1] + arg.storage[1] * factor;
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0] * factor;
+    _storage[1] = _storage[1] + argStorage[1] * factor;
     return this;
   }
 
   /// Subtract [arg] from [this].
   Vector2 sub(Vector2 arg) {
-    storage[0] = storage[0] - arg.storage[0];
-    storage[1] = storage[1] - arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] - argStorage[0];
+    _storage[1] = _storage[1] - argStorage[1];
     return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
   Vector2 multiply(Vector2 arg) {
-    storage[0] = storage[0] * arg.storage[0];
-    storage[1] = storage[1] * arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] * argStorage[0];
+    _storage[1] = _storage[1] * argStorage[1];
     return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
   Vector2 divide(Vector2 arg) {
-    storage[0] = storage[0] / arg.storage[0];
-    storage[1] = storage[1] / arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] / argStorage[0];
+    _storage[1] = _storage[1] / argStorage[1];
     return this;
   }
 
-  /// Scale [this].
+  /// Scale [this] by [arg].
   Vector2 scale(double arg) {
-    storage[1] = storage[1] * arg;
-    storage[0] = storage[0] * arg;
+    _storage[1] = _storage[1] * arg;
+    _storage[0] = _storage[0] * arg;
     return this;
   }
 
-  Vector2 scaled(double arg) {
-    return clone().scale(arg);
-  }
+  /// Return a copy of [this] scaled by [arg].
+  Vector2 scaled(double arg) => clone()..scale(arg);
 
   /// Negate.
   Vector2 negate() {
-    storage[1] = -storage[1];
-    storage[0] = -storage[0];
+    _storage[1] = -_storage[1];
+    _storage[0] = -_storage[0];
     return this;
   }
 
   /// Absolute value.
   Vector2 absolute() {
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    _storage[1] = _storage[1].abs();
+    _storage[0] = _storage[0].abs();
     return this;
   }
-  
+
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
   Vector2 clamp(Vector2 min, Vector2 max) {
-    storage[0] = storage[0].clamp(min.storage[0], max.storage[0]);
-    storage[1] = storage[1].clamp(min.storage[1], max.storage[1]);
+    _storage[0] = _storage[0].clamp(min.storage[0], max.storage[0]);
+    _storage[1] = _storage[1].clamp(min.storage[1], max.storage[1]);
     return this;
   }
-  
+
   /// Clamp entries [this] in the range [min]-[max].
   Vector2 clampScalar(double min, double max) {
-    storage[0] = storage[0].clamp(min, max);
-    storage[1] = storage[1].clamp(min, max);
+    _storage[0] = _storage[0].clamp(min, max);
+    _storage[1] = _storage[1].clamp(min, max);
     return this;
   }
-  
+
   /// Floor entries in [this].
   Vector2 floor() {
-    storage[0] = storage[0].floorToDouble();
-    storage[1] = storage[1].floorToDouble();
+    _storage[0] = _storage[0].floorToDouble();
+    _storage[1] = _storage[1].floorToDouble();
     return this;
   }
-  
+
   /// Ceil entries in [this].
   Vector2 ceil() {
-    storage[0] = storage[0].ceilToDouble();
-    storage[1] = storage[1].ceilToDouble();
+    _storage[0] = _storage[0].ceilToDouble();
+    _storage[1] = _storage[1].ceilToDouble();
     return this;
   }
-  
+
   /// Round entries in [this].
   Vector2 round() {
-    storage[0] = storage[0].roundToDouble();
-    storage[1] = storage[1].roundToDouble();
+    _storage[0] = _storage[0].roundToDouble();
+    _storage[1] = _storage[1].roundToDouble();
     return this;
   }
-  
+
   /// Round entries in [this] towards zero.
   Vector2 roundToZero() {
-    storage[0] = storage[0] < 0.0 ? storage[0].ceilToDouble() : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0 ? storage[1].ceilToDouble() : storage[1].floorToDouble();
+    _storage[0] = _storage[0] < 0.0
+        ? _storage[0].ceilToDouble()
+        : _storage[0].floorToDouble();
+    _storage[1] = _storage[1] < 0.0
+        ? _storage[1].ceilToDouble()
+        : _storage[1].floorToDouble();
     return this;
   }
 
   /// Clone of [this].
-  Vector2 clone() {
-    return new Vector2.copy(this);
-  }
+  Vector2 clone() => new Vector2.copy(this);
 
   /// Copy [this] into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    arg.storage[1] = storage[1];
-    arg.storage[0] = storage[0];
+    final argStorage = arg._storage;
+    argStorage[1] = _storage[1];
+    argStorage[0] = _storage[0];
     return arg;
   }
 
   /// Copies [this] into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = storage[1];
-    array[offset + 0] = storage[0];
+    array[offset + 1] = _storage[1];
+    array[offset + 0] = _storage[0];
   }
 
   /// Copies elements from [array] into [this] starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[1] = array[offset + 1];
-    storage[0] = array[offset + 0];
+    _storage[1] = array[offset + 1];
+    _storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set yx(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
-  set r(double arg) => storage[0] = arg;
-  set g(double arg) => storage[1] = arg;
-  set s(double arg) => storage[0] = arg;
-  set t(double arg) => storage[1] = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
-  set rg(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set gr(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set st(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ts(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  Vector2 get xx => new Vector2(storage[0], storage[0]);
-  Vector2 get xy => new Vector2(storage[0], storage[1]);
-  Vector2 get yx => new Vector2(storage[1], storage[0]);
-  Vector2 get yy => new Vector2(storage[1], storage[1]);
-  Vector3 get xxx => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xyx => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get yxx => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yyx => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => new Vector3(storage[1], storage[1], storage[1]);
+  set r(double arg) => x = arg;
+  set g(double arg) => y = arg;
+  set s(double arg) => x = arg;
+  set t(double arg) => y = arg;
+  set x(double arg) => _storage[0] = arg;
+  set y(double arg) => _storage[1] = arg;
+  set rg(Vector2 arg) => xy = arg;
+  set gr(Vector2 arg) => yx = arg;
+  set st(Vector2 arg) => xy = arg;
+  set ts(Vector2 arg) => yx = arg;
+  Vector2 get xx => new Vector2(_storage[0], _storage[0]);
+  Vector2 get xy => new Vector2(_storage[0], _storage[1]);
+  Vector2 get yx => new Vector2(_storage[1], _storage[0]);
+  Vector2 get yy => new Vector2(_storage[1], _storage[1]);
+  Vector3 get xxx => new Vector3(_storage[0], _storage[0], _storage[0]);
+  Vector3 get xxy => new Vector3(_storage[0], _storage[0], _storage[1]);
+  Vector3 get xyx => new Vector3(_storage[0], _storage[1], _storage[0]);
+  Vector3 get xyy => new Vector3(_storage[0], _storage[1], _storage[1]);
+  Vector3 get yxx => new Vector3(_storage[1], _storage[0], _storage[0]);
+  Vector3 get yxy => new Vector3(_storage[1], _storage[0], _storage[1]);
+  Vector3 get yyx => new Vector3(_storage[1], _storage[1], _storage[0]);
+  Vector3 get yyy => new Vector3(_storage[1], _storage[1], _storage[1]);
   Vector4 get xxxx =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[0]);
   Vector4 get xxxy =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[1]);
   Vector4 get xxyx =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[0]);
   Vector4 get xxyy =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[1]);
   Vector4 get xyxx =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[0]);
   Vector4 get xyxy =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[1]);
   Vector4 get xyyx =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[0]);
   Vector4 get xyyy =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[1]);
   Vector4 get yxxx =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[0]);
   Vector4 get yxxy =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[1]);
   Vector4 get yxyx =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[0]);
   Vector4 get yxyy =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[1]);
   Vector4 get yyxx =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[0]);
   Vector4 get yyxy =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[1]);
   Vector4 get yyyx =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[0]);
   Vector4 get yyyy =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  double get r => storage[0];
-  double get g => storage[1];
-  double get s => storage[0];
-  double get t => storage[1];
-  double get x => storage[0];
-  double get y => storage[1];
-  Vector2 get rr => new Vector2(storage[0], storage[0]);
-  Vector2 get rg => new Vector2(storage[0], storage[1]);
-  Vector2 get gr => new Vector2(storage[1], storage[0]);
-  Vector2 get gg => new Vector2(storage[1], storage[1]);
-  Vector3 get rrr => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get rrg => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get rgr => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get rgg => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get grr => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get grg => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get ggr => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ggg => new Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get rrrr =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get rrrg =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get rrgr =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get rrgg =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get rgrr =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get rgrg =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get rggr =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get rggg =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get grrr =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get grrg =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get grgr =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get grgg =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get ggrr =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ggrg =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get gggr =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get gggg =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector2 get ss => new Vector2(storage[0], storage[0]);
-  Vector2 get st => new Vector2(storage[0], storage[1]);
-  Vector2 get ts => new Vector2(storage[1], storage[0]);
-  Vector2 get tt => new Vector2(storage[1], storage[1]);
-  Vector3 get sss => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get sst => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get sts => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get stt => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get tss => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get tst => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get tts => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ttt => new Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get ssss =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get ssst =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get ssts =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get sstt =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get stss =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get stst =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get stts =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get sttt =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get tsss =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get tsst =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get tsts =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get tstt =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get ttss =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ttst =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ttts =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get tttt =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[1]);
+  double get r => x;
+  double get g => y;
+  double get s => x;
+  double get t => y;
+  double get x => _storage[0];
+  double get y => _storage[1];
+  Vector2 get rr => xx;
+  Vector2 get rg => xy;
+  Vector2 get gr => yx;
+  Vector2 get gg => yy;
+  Vector3 get rrr => xxx;
+  Vector3 get rrg => xxy;
+  Vector3 get rgr => xyx;
+  Vector3 get rgg => xyy;
+  Vector3 get grr => yxx;
+  Vector3 get grg => yxy;
+  Vector3 get ggr => yyx;
+  Vector3 get ggg => yyy;
+  Vector4 get rrrr => xxxx;
+  Vector4 get rrrg => xxxy;
+  Vector4 get rrgr => xxyx;
+  Vector4 get rrgg => xxyy;
+  Vector4 get rgrr => xyxx;
+  Vector4 get rgrg => xyxy;
+  Vector4 get rggr => xyyx;
+  Vector4 get rggg => xyyy;
+  Vector4 get grrr => yxxx;
+  Vector4 get grrg => yxxy;
+  Vector4 get grgr => yxyx;
+  Vector4 get grgg => yxyy;
+  Vector4 get ggrr => yyxx;
+  Vector4 get ggrg => yyxy;
+  Vector4 get gggr => yyyx;
+  Vector4 get gggg => yyyy;
+  Vector2 get ss => xx;
+  Vector2 get st => xy;
+  Vector2 get ts => yx;
+  Vector2 get tt => yy;
+  Vector3 get sss => xxx;
+  Vector3 get sst => xxy;
+  Vector3 get sts => xyx;
+  Vector3 get stt => xyy;
+  Vector3 get tss => yxx;
+  Vector3 get tst => yxy;
+  Vector3 get tts => yyx;
+  Vector3 get ttt => yyy;
+  Vector4 get ssss => xxxx;
+  Vector4 get ssst => xxxy;
+  Vector4 get ssts => xxyx;
+  Vector4 get sstt => xxyy;
+  Vector4 get stss => xyxx;
+  Vector4 get stst => xyxy;
+  Vector4 get stts => xyyx;
+  Vector4 get sttt => xyyy;
+  Vector4 get tsss => yxxx;
+  Vector4 get tsst => yxxy;
+  Vector4 get tsts => yxyx;
+  Vector4 get tstt => yxyy;
+  Vector4 get ttss => yyxx;
+  Vector4 get ttst => yyxy;
+  Vector4 get ttts => yyyx;
+  Vector4 get tttt => yyyy;
 }

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -4,11 +4,35 @@
 
 library vector_math.test.vector2_test;
 
+import 'dart:typed_data';
+
 import 'package:unittest/unittest.dart';
 
 import 'package:vector_math/vector_math.dart';
 
 import 'test_utils.dart';
+
+void testVector2InstacinfFromFloat32List() {
+  final float32List = new Float32List.fromList([1.0, 2.0]);
+  final input = new Vector2.fromFloat32List(float32List);
+
+  expect(input.x, equals(1.0));
+  expect(input.y, equals(2.0));
+}
+
+void testVector2InstacingFromByteBuffer() {
+  final float32List = new Float32List.fromList([1.0, 2.0, 3.0, 4.0]);
+  final buffer = float32List.buffer;
+  final zeroOffset = new Vector2.fromBuffer(buffer, 0);
+  final offsetVector =
+      new Vector2.fromBuffer(buffer, Float32List.BYTES_PER_ELEMENT);
+
+  expect(zeroOffset.x, equals(1.0));
+  expect(zeroOffset.y, equals(2.0));
+
+  expect(offsetVector.x, equals(2.0));
+  expect(offsetVector.y, equals(3.0));
+}
 
 void testVector2Add() {
   final Vector2 a = new Vector2(5.0, 7.0);
@@ -267,6 +291,8 @@ void main() {
     test('mix', testVector2Mix);
     test('distanceTo', testVector2DistanceTo);
     test('distanceToSquared', testVector2DistanceToSquared);
+    test('instancing from Float32List', testVector2InstacinfFromFloat32List);
+    test('instancing from ByteBuffer', testVector2InstacingFromByteBuffer);
     test('clamp', testVector2Clamp);
     test('clampScalar', testVector2ClampScalar);
     test('floor', testVector2Floor);

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -191,11 +191,12 @@ void testVector2DistanceToSquared() {
 }
 
 void testVector2Clamp() {
-  final x = 2.0, y = 3.0;
+  final x = 2.0,
+      y = 3.0;
   final v0 = new Vector2(x, y);
   final v1 = new Vector2(-x, -y);
   final v2 = new Vector2(-2.0 * x, 2.0 * y)..clamp(v1, v0);
-  
+
   expect(v2.storage, orderedEquals([-x, y]));
 }
 
@@ -209,7 +210,7 @@ void testVector2Floor() {
   final v0 = new Vector2(-0.1, 0.1)..floor();
   final v1 = new Vector2(-0.5, 0.5)..floor();
   final v2 = new Vector2(-0.9, 0.9)..floor();
-  
+
   expect(v0.storage, orderedEquals([-1.0, 0.0]));
   expect(v1.storage, orderedEquals([-1.0, 0.0]));
   expect(v2.storage, orderedEquals([-1.0, 0.0]));
@@ -219,7 +220,7 @@ void testVector2Ceil() {
   final v0 = new Vector2(-0.1, 0.1)..ceil();
   final v1 = new Vector2(-0.5, 0.5)..ceil();
   final v2 = new Vector2(-0.9, 0.9)..ceil();
-  
+
   expect(v0.storage, orderedEquals([0.0, 1.0]));
   expect(v1.storage, orderedEquals([0.0, 1.0]));
   expect(v2.storage, orderedEquals([0.0, 1.0]));
@@ -229,7 +230,7 @@ void testVector2Round() {
   final v0 = new Vector2(-0.1, 0.1)..round();
   final v1 = new Vector2(-0.5, 0.5)..round();
   final v2 = new Vector2(-0.9, 0.9)..round();
-  
+
   expect(v0.storage, orderedEquals([0.0, 0.0]));
   expect(v1.storage, orderedEquals([-1.0, 1.0]));
   expect(v2.storage, orderedEquals([-1.0, 1.0]));
@@ -242,7 +243,7 @@ void testVector2RoundToZero() {
   final v3 = new Vector2(-1.1, 1.1)..roundToZero();
   final v4 = new Vector2(-1.5, 1.5)..roundToZero();
   final v5 = new Vector2(-1.9, 1.9)..roundToZero();
-  
+
   expect(v0.storage, orderedEquals([0.0, 0.0]));
   expect(v1.storage, orderedEquals([0.0, 0.0]));
   expect(v2.storage, orderedEquals([0.0, 0.0]));


### PR DESCRIPTION
- Remove duplicate implementation of some operations: they now delegate calls to another other method (e.g. add operator vs add method or length and length2). Inlining should make the whole thing perform as it did before.
- When a Vector is a argument, only get its storage once.
- Always access the private storage variable, this is a preparation for a future change.
- Doc comments.
- Making the shuffle getters aliases help to reduce the lines of the file, but the impact for Vector2 is quite small compated to Vector4.