### PR TITLE
Cleanup vector4

### DIFF
--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -6,7 +6,7 @@ part of vector_math;
 
 /// 4D column vector.
 class Vector4 implements Vector {
-  final Float32List storage = new Float32List(4);
+  final Float32List _storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector4 a, Vector4 b, Vector4 result) {
@@ -24,8 +24,8 @@ class Vector4 implements Vector {
     result.w = Math.max(a.w, b.w);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear
-  // interpolation and set the values to [result].
+  /// Interpolate between [min] and [max] with the amount of [a] using a linear
+  /// interpolation and store the values in [result].
   static void mix(Vector4 min, Vector4 max, double a, Vector4 result) {
     result.x = min.x + a * (max.x - min.x);
     result.y = min.y + a * (max.y - min.y);
@@ -33,127 +33,120 @@ class Vector4 implements Vector {
     result.w = min.w + a * (max.w - min.w);
   }
 
-  /// Constructs a new vector with the specified values.
-  Vector4(double x_, double y_, double z_, double w_) {
-    setValues(x_, y_, z_, w_);
-  }
+  /// The components of the vector.
+  Float32List get storage => _storage;
+
+  /// Construct a new vector with the specified values.
+  factory Vector4(double x, double y, double z, double w) =>
+      new Vector4.zero()..setValues(x, y, z, w);
 
   /// Initialized with values from [array] starting at [offset].
-  Vector4.array(List<double> array, [int offset = 0]) {
-    int i = offset;
-    storage[0] = array[i + 0];
-    storage[1] = array[i + 1];
-    storage[2] = array[i + 2];
-    storage[3] = array[i + 3];
-  }
+  factory Vector4.array(List<double> array, [int offset = 0]) =>
+      new Vector4.zero()..copyFromArray(array, offset);
 
-  //// Zero vector.
-  Vector4.zero();
+  /// Zero vector.
+  Vector4.zero() : _storage = new Float32List(4);
 
   /// Constructs the identity vector.
-  Vector4.identity() {
-    storage[3] = 1.0;
-  }
+  factory Vector4.identity() => new Vector4.zero()..setIdentity();
 
   /// Splat [value] into all lanes of the vector.
-  Vector4.all(double value) : this(value, value, value, value);
+  factory Vector4.all(double value) => new Vector4.zero()..splat(value);
 
   /// Copy of [other].
-  Vector4.copy(Vector4 other) {
-    setFrom(other);
-  }
+  factory Vector4.copy(Vector4 other) => new Vector4.zero()..setFrom(other);
+
+  /// Constructs Vector4 with given Float32List as [storage].
+  Vector4.fromFloat32List(this._storage);
+
+  /// Constructs Vector4 with a [storage] that views given [buffer] starting at
+  /// [offset]. [offset] has to be multiple of [Float32List.BYTES_PER_ELEMENT].
+  Vector4.fromBuffer(ByteBuffer buffer, int offset)
+      : _storage = new Float32List.view(buffer, offset, 4);
 
   /// Set the values of the vector.
   Vector4 setValues(double x_, double y_, double z_, double w_) {
-    storage[3] = w_;
-    storage[2] = z_;
-    storage[1] = y_;
-    storage[0] = x_;
+    _storage[3] = w_;
+    _storage[2] = z_;
+    _storage[1] = y_;
+    _storage[0] = x_;
     return this;
   }
 
   /// Zero the vector.
   Vector4 setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
-    storage[2] = 0.0;
-    storage[3] = 0.0;
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
+    _storage[2] = 0.0;
+    _storage[3] = 0.0;
+    return this;
+  }
+
+  /// Set to the identity vector.
+  Vector4 setIdentity() {
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
+    _storage[2] = 0.0;
+    _storage[3] = 1.0;
     return this;
   }
 
   /// Set the values by copying them from [other].
   Vector4 setFrom(Vector4 other) {
-    storage[3] = other.storage[3];
-    storage[2] = other.storage[2];
-    storage[1] = other.storage[1];
-    storage[0] = other.storage[0];
+    final otherStorage = other._storage;
+    _storage[3] = otherStorage[3];
+    _storage[2] = otherStorage[2];
+    _storage[1] = otherStorage[1];
+    _storage[0] = otherStorage[0];
     return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
   Vector4 splat(double arg) {
-    storage[3] = arg;
-    storage[2] = arg;
-    storage[1] = arg;
-    storage[0] = arg;
+    _storage[3] = arg;
+    _storage[2] = arg;
+    _storage[1] = arg;
+    _storage[0] = arg;
     return this;
   }
 
   /// Returns a printable string
-  String toString() => '${storage[0]},${storage[1]},'
-      '${storage[2]},${storage[3]}';
+  String toString() => '${_storage[0]},${_storage[1]},'
+      '${_storage[2]},${_storage[3]}';
 
   /// Negate.
-  Vector4 operator -() =>
-      new Vector4(-storage[0], -storage[1], -storage[2], -storage[3]);
+  Vector4 operator -() => clone()..negate();
 
   /// Subtract two vectors.
-  Vector4 operator -(Vector4 other) => new Vector4(
-      storage[0] - other.storage[0], storage[1] - other.storage[1],
-      storage[2] - other.storage[2], storage[3] - other.storage[3]);
+  Vector4 operator -(Vector4 other) => clone()..sub(other);
 
   /// Add two vectors.
-  Vector4 operator +(Vector4 other) => new Vector4(
-      storage[0] + other.storage[0], storage[1] + other.storage[1],
-      storage[2] + other.storage[2], storage[3] + other.storage[3]);
+  Vector4 operator +(Vector4 other) => clone()..add(other);
 
   /// Scale.
-  Vector4 operator /(double scale) {
-    var o = 1.0 / scale;
-    return new Vector4(
-        storage[0] * o, storage[1] * o, storage[2] * o, storage[3] * o);
-  }
+  Vector4 operator /(double scale) => clone()..scale(1.0 / scale);
 
   /// Scale.
-  Vector4 operator *(double scale) {
-    var o = scale;
-    return new Vector4(
-        storage[0] * o, storage[1] * o, storage[2] * o, storage[3] * o);
-  }
+  Vector4 operator *(double scale) => clone()..scale(scale);
 
-  double operator [](int i) => storage[i];
+  /// Access the component of the vector at the index [i].
+  double operator [](int i) => _storage[i];
 
+  /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    storage[i] = v;
+    _storage[i] = v;
   }
 
   /// Length.
-  double get length {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    sum += (storage[2] * storage[2]);
-    sum += (storage[3] * storage[3]);
-    return Math.sqrt(sum);
-  }
+  double get length => Math.sqrt(length2);
 
   /// Length squared.
   double get length2 {
     double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    sum += (storage[2] * storage[2]);
-    sum += (storage[3] * storage[3]);
+    sum = (_storage[0] * _storage[0]);
+    sum += (_storage[1] * _storage[1]);
+    sum += (_storage[2] * _storage[2]);
+    sum += (_storage[3] * _storage[3]);
     return sum;
   }
 
@@ -165,10 +158,10 @@ class Vector4 implements Vector {
       return this;
     }
     l = 1.0 / l;
-    storage[0] *= l;
-    storage[1] *= l;
-    storage[2] *= l;
-    storage[3] *= l;
+    _storage[0] *= l;
+    _storage[1] *= l;
+    _storage[2] *= l;
+    _storage[3] *= l;
     return this;
   }
 
@@ -179,17 +172,15 @@ class Vector4 implements Vector {
       return 0.0;
     }
     var d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
-    storage[2] *= d;
-    storage[3] *= d;
+    _storage[0] *= d;
+    _storage[1] *= d;
+    _storage[2] *= d;
+    _storage[3] *= d;
     return l;
   }
 
   /// Normalizes copy of [this].
-  Vector4 normalized() {
-    return new Vector4.copy(this).normalize();
-  }
+  Vector4 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector4 normalizeInto(Vector4 out) {
@@ -202,21 +193,23 @@ class Vector4 implements Vector {
 
   /// Squared distance from [this] to [arg]
   double distanceToSquared(Vector4 arg) {
-    final dx = x - arg.x;
-    final dy = y - arg.y;
-    final dz = z - arg.z;
-    final dw = w - arg.w;
+    final argStorage = arg._storage;
+    final dx = _storage[0] - argStorage[0];
+    final dy = _storage[1] - argStorage[1];
+    final dz = _storage[2] - argStorage[2];
+    final dw = _storage[3] - argStorage[3];
 
     return dx * dx + dy * dy + dz * dz + dw * dw;
   }
 
   /// Inner product.
   double dot(Vector4 other) {
+    final otherStorage = other._storage;
     double sum;
-    sum = storage[0] * other.storage[0];
-    sum += storage[1] * other.storage[1];
-    sum += storage[2] * other.storage[2];
-    sum += storage[3] * other.storage[3];
+    sum = _storage[0] * otherStorage[0];
+    sum += _storage[1] * otherStorage[1];
+    sum += _storage[2] * otherStorage[2];
+    sum += _storage[3] * otherStorage[3];
     return sum;
   }
 
@@ -235,93 +228,103 @@ class Vector4 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     bool is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
-    is_infinite = is_infinite || storage[2].isInfinite;
-    is_infinite = is_infinite || storage[3].isInfinite;
+    is_infinite = is_infinite || _storage[0].isInfinite;
+    is_infinite = is_infinite || _storage[1].isInfinite;
+    is_infinite = is_infinite || _storage[2].isInfinite;
+    is_infinite = is_infinite || _storage[3].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     bool is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
-    is_nan = is_nan || storage[2].isNaN;
-    is_nan = is_nan || storage[3].isNaN;
+    is_nan = is_nan || _storage[0].isNaN;
+    is_nan = is_nan || _storage[1].isNaN;
+    is_nan = is_nan || _storage[2].isNaN;
+    is_nan = is_nan || _storage[3].isNaN;
     return is_nan;
   }
 
   Vector4 add(Vector4 arg) {
-    storage[0] = storage[0] + arg.storage[0];
-    storage[1] = storage[1] + arg.storage[1];
-    storage[2] = storage[2] + arg.storage[2];
-    storage[3] = storage[3] + arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0];
+    _storage[1] = _storage[1] + argStorage[1];
+    _storage[2] = _storage[2] + argStorage[2];
+    _storage[3] = _storage[3] + argStorage[3];
     return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
   Vector4 addScaled(Vector4 arg, double factor) {
-    storage[0] = storage[0] + arg.storage[0] * factor;
-    storage[1] = storage[1] + arg.storage[1] * factor;
-    storage[2] = storage[2] + arg.storage[2] * factor;
-    storage[3] = storage[3] + arg.storage[3] * factor;
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0] * factor;
+    _storage[1] = _storage[1] + argStorage[1] * factor;
+    _storage[2] = _storage[2] + argStorage[2] * factor;
+    _storage[3] = _storage[3] + argStorage[3] * factor;
     return this;
   }
 
+  /// Subtract [arg] from [this].
   Vector4 sub(Vector4 arg) {
-    storage[0] = storage[0] - arg.storage[0];
-    storage[1] = storage[1] - arg.storage[1];
-    storage[2] = storage[2] - arg.storage[2];
-    storage[3] = storage[3] - arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] - argStorage[0];
+    _storage[1] = _storage[1] - argStorage[1];
+    _storage[2] = _storage[2] - argStorage[2];
+    _storage[3] = _storage[3] - argStorage[3];
     return this;
   }
 
+  /// Multiply [this] by [arg].
   Vector4 multiply(Vector4 arg) {
-    storage[0] = storage[0] * arg.storage[0];
-    storage[1] = storage[1] * arg.storage[1];
-    storage[2] = storage[2] * arg.storage[2];
-    storage[3] = storage[3] * arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] * argStorage[0];
+    _storage[1] = _storage[1] * argStorage[1];
+    _storage[2] = _storage[2] * argStorage[2];
+    _storage[3] = _storage[3] * argStorage[3];
     return this;
   }
 
+  /// Divide [this] by [arg].
   Vector4 div(Vector4 arg) {
-    storage[0] = storage[0] / arg.storage[0];
-    storage[1] = storage[1] / arg.storage[1];
-    storage[2] = storage[2] / arg.storage[2];
-    storage[3] = storage[3] / arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] / argStorage[0];
+    _storage[1] = _storage[1] / argStorage[1];
+    _storage[2] = _storage[2] / argStorage[2];
+    _storage[3] = _storage[3] / argStorage[3];
     return this;
   }
 
+  /// Scale [this] by [arg].
   Vector4 scale(double arg) {
-    storage[0] = storage[0] * arg;
-    storage[1] = storage[1] * arg;
-    storage[2] = storage[2] * arg;
-    storage[3] = storage[3] * arg;
+    _storage[0] = _storage[0] * arg;
+    _storage[1] = _storage[1] * arg;
+    _storage[2] = _storage[2] * arg;
+    _storage[3] = _storage[3] * arg;
     return this;
   }
 
-  Vector4 scaled(double arg) {
-    return clone().scale(arg);
-  }
+  /// Create a copy of [this] scaled by [arg].
+  Vector4 scaled(double arg) => clone()..scale(arg);
 
+  /// Negate [this].
   Vector4 negate() {
-    storage[0] = -storage[0];
-    storage[1] = -storage[1];
-    storage[2] = -storage[2];
-    storage[3] = -storage[3];
+    _storage[0] = -_storage[0];
+    _storage[1] = -_storage[1];
+    _storage[2] = -_storage[2];
+    _storage[3] = -_storage[3];
     return this;
   }
 
+  /// Set [this] to the absolute.
   Vector4 absolute() {
-    storage[3] = storage[3].abs();
-    storage[2] = storage[2].abs();
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    _storage[3] = _storage[3].abs();
+    _storage[2] = _storage[2].abs();
+    _storage[1] = _storage[1].abs();
+    _storage[0] = _storage[0].abs();
     return this;
   }
-  
-  /// Clamp each entry n in [this] in the range [min[n]]-[max[n]]. 
+
+  /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
   Vector4 clamp(Vector4 min, Vector4 max) {
     storage[0] = storage[0].clamp(min.storage[0], max.storage[0]);
     storage[1] = storage[1].clamp(min.storage[1], max.storage[1]);
@@ -329,7 +332,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].clamp(min.storage[3], max.storage[3]);
     return this;
   }
-  
+
   /// Clamp entries in [this] in the range [min]-[max].
   Vector4 clampScalar(double min, double max) {
     storage[0] = storage[0].clamp(min, max);
@@ -338,7 +341,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].clamp(min, max);
     return this;
   }
-  
+
   /// Floor entries in [this].
   Vector4 floor() {
     storage[0] = storage[0].floorToDouble();
@@ -347,7 +350,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].floorToDouble();
     return this;
   }
-  
+
   /// Ceil entries in [this].
   Vector4 ceil() {
     storage[0] = storage[0].ceilToDouble();
@@ -356,7 +359,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].ceilToDouble();
     return this;
   }
-  
+
   /// Round entries in [this].
   Vector4 round() {
     storage[0] = storage[0].roundToDouble();
@@ -365,2778 +368,1831 @@ class Vector4 implements Vector {
     storage[3] = storage[3].roundToDouble();
     return this;
   }
-  
+
   /// Round entries in [this] towards zero.
   Vector4 roundToZero() {
-    storage[0] = storage[0] < 0.0 ? storage[0].ceilToDouble() : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0 ? storage[1].ceilToDouble() : storage[1].floorToDouble();
-    storage[2] = storage[2] < 0.0 ? storage[2].ceilToDouble() : storage[2].floorToDouble();
-    storage[3] = storage[3] < 0.0 ? storage[3].ceilToDouble() : storage[3].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
+    storage[2] = storage[2] < 0.0
+        ? storage[2].ceilToDouble()
+        : storage[2].floorToDouble();
+    storage[3] = storage[3] < 0.0
+        ? storage[3].ceilToDouble()
+        : storage[3].floorToDouble();
     return this;
   }
 
-  Vector4 clone() {
-    return new Vector4.copy(this);
-  }
+  /// Create a copy of [this].
+  Vector4 clone() => new Vector4.copy(this);
 
+  /// Copy [this]
   Vector4 copyInto(Vector4 arg) {
-    arg.storage[0] = storage[0];
-    arg.storage[1] = storage[1];
-    arg.storage[2] = storage[2];
-    arg.storage[3] = storage[3];
+    final argStorage = arg._storage;
+    argStorage[0] = _storage[0];
+    argStorage[1] = _storage[1];
+    argStorage[2] = _storage[2];
+    argStorage[3] = _storage[3];
     return arg;
   }
 
   /// Copies [this] into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 0] = storage[0];
-    array[offset + 1] = storage[1];
-    array[offset + 2] = storage[2];
-    array[offset + 3] = storage[3];
+    array[offset + 0] = _storage[0];
+    array[offset + 1] = _storage[1];
+    array[offset + 2] = _storage[2];
+    array[offset + 3] = _storage[3];
   }
 
   /// Copies elements from [array] into [this] starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[0] = array[offset + 0];
-    storage[1] = array[offset + 1];
-    storage[2] = array[offset + 2];
-    storage[3] = array[offset + 3];
+    _storage[0] = array[offset + 0];
+    _storage[1] = array[offset + 1];
+    _storage[2] = array[offset + 2];
+    _storage[3] = array[offset + 3];
   }
 
   set xy(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set xz(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set xw(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set yx(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set yz(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set yw(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set zx(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set zy(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set zw(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set wx(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set wy(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set wz(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set xyz(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set xyw(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set xzy(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xzw(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set xwy(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xwz(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set yxz(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set yxw(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set yzx(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set yzw(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set ywx(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set ywz(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set zxy(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set zxw(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set zyx(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set zyw(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set zwx(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set zwy(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set wxy(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set wxz(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set wyx(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set wyz(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set wzx(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set wzy(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xyzw(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set xywz(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set xzyw(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set xzwy(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set xwyz(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set xwzy(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set yxzw(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set yxwz(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set yzxw(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set yzwx(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set ywxz(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set ywzx(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set zxyw(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set zxwy(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set zyxw(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set zywx(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set zwxy(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set zwyx(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set wxyz(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set wxzy(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set wyxz(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set wyzx(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set wzxy(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set wzyx(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set r(double arg) => storage[0] = arg;
-  set g(double arg) => storage[1] = arg;
-  set b(double arg) => storage[2] = arg;
-  set a(double arg) => storage[3] = arg;
-  set s(double arg) => storage[0] = arg;
-  set t(double arg) => storage[1] = arg;
-  set p(double arg) => storage[2] = arg;
-  set q(double arg) => storage[3] = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
-  set z(double arg) => storage[2] = arg;
-  set w(double arg) => storage[3] = arg;
-  set rg(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set rb(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set ra(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set gr(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set gb(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set ga(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set br(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set bg(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ba(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ar(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set ag(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ab(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set rgb(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set rga(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set rbg(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rba(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set rag(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rab(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set grb(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set gra(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set gbr(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set gba(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set gar(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set gab(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set brg(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set bra(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set bgr(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set bga(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set bar(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set bag(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set arg(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set arb(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set agr(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set agb(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set abr(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set abg(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rgba(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set rgab(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set rbga(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set rbag(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set ragb(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set rabg(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set grba(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set grab(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set gbra(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set gbar(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set garb(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set gabr(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set brga(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set brag(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set bgra(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set bgar(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set barg(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set bagr(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set argb(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set arbg(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set agrb(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set agbr(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set abrg(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set abgr(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set st(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set sp(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set sq(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ts(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set tp(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set tq(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ps(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set pt(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set pq(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set qs(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set qt(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set qp(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set stp(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set stq(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set spt(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set spq(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set sqt(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set sqp(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set tsp(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set tsq(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set tps(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set tpq(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set tqs(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set tqp(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set pst(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set psq(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set pts(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set ptq(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set pqs(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set pqt(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set qst(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set qsp(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set qts(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set qtp(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set qps(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set qpt(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set stpq(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set stqp(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set sptq(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set spqt(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set sqtp(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set sqpt(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set tspq(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set tsqp(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set tpsq(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set tpqs(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set tqsp(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set tqps(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set pstq(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set psqt(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set ptsq(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set ptqs(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set pqst(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set pqts(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set qstp(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set qspt(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set qtsp(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set qtps(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set qpst(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set qpts(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  Vector2 get xx => new Vector2(storage[0], storage[0]);
-  Vector2 get xy => new Vector2(storage[0], storage[1]);
-  Vector2 get xz => new Vector2(storage[0], storage[2]);
-  Vector2 get xw => new Vector2(storage[0], storage[3]);
-  Vector2 get yx => new Vector2(storage[1], storage[0]);
-  Vector2 get yy => new Vector2(storage[1], storage[1]);
-  Vector2 get yz => new Vector2(storage[1], storage[2]);
-  Vector2 get yw => new Vector2(storage[1], storage[3]);
-  Vector2 get zx => new Vector2(storage[2], storage[0]);
-  Vector2 get zy => new Vector2(storage[2], storage[1]);
-  Vector2 get zz => new Vector2(storage[2], storage[2]);
-  Vector2 get zw => new Vector2(storage[2], storage[3]);
-  Vector2 get wx => new Vector2(storage[3], storage[0]);
-  Vector2 get wy => new Vector2(storage[3], storage[1]);
-  Vector2 get wz => new Vector2(storage[3], storage[2]);
-  Vector2 get ww => new Vector2(storage[3], storage[3]);
-  Vector3 get xxx => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xxz => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get xxw => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get xyx => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get xyz => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get xyw => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get xzx => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get xzy => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get xzz => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get xzw => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get xwx => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get xwy => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get xwz => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get xww => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get yxx => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yxz => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get yxw => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get yyx => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get yyz => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get yyw => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get yzx => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get yzy => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get yzz => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get yzw => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get ywx => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get ywy => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get ywz => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get yww => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get zxx => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get zxy => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get zxz => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get zxw => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get zyx => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get zyy => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get zyz => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get zyw => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get zzx => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get zzy => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get zzz => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get zzw => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get zwx => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get zwy => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get zwz => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get zww => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get wxx => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get wxy => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get wxz => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get wxw => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get wyx => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get wyy => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get wyz => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get wyw => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get wzx => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get wzy => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get wzz => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get wzw => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get wwx => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get wwy => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get wwz => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get www => new Vector3(storage[3], storage[3], storage[3]);
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[0] = argStorage[3];
+  }
+  set r(double arg) => x = arg;
+  set g(double arg) => y = arg;
+  set b(double arg) => z = arg;
+  set a(double arg) => w = arg;
+  set s(double arg) => x = arg;
+  set t(double arg) => y = arg;
+  set p(double arg) => z = arg;
+  set q(double arg) => w = arg;
+  set x(double arg) => _storage[0] = arg;
+  set y(double arg) => _storage[1] = arg;
+  set z(double arg) => _storage[2] = arg;
+  set w(double arg) => _storage[3] = arg;
+  set rg(Vector2 arg) => xy = arg;
+  set rb(Vector2 arg) => xz = arg;
+  set ra(Vector2 arg) => xw = arg;
+  set gr(Vector2 arg) => yx = arg;
+  set gb(Vector2 arg) => yz = arg;
+  set ga(Vector2 arg) => yw = arg;
+  set br(Vector2 arg) => zx = arg;
+  set bg(Vector2 arg) => zy = arg;
+  set ba(Vector2 arg) => zw = arg;
+  set ar(Vector2 arg) => wx = arg;
+  set ag(Vector2 arg) => wy = arg;
+  set ab(Vector2 arg) => wz = arg;
+  set rgb(Vector3 arg) => xyz = arg;
+  set rga(Vector3 arg) => xyw = arg;
+  set rbg(Vector3 arg) => xzy = arg;
+  set rba(Vector3 arg) => xzw = arg;
+  set rag(Vector3 arg) => xwy = arg;
+  set rab(Vector3 arg) => xwz = arg;
+  set grb(Vector3 arg) => yxz = arg;
+  set gra(Vector3 arg) => yxw = arg;
+  set gbr(Vector3 arg) => yzx = arg;
+  set gba(Vector3 arg) => yzw = arg;
+  set gar(Vector3 arg) => ywx = arg;
+  set gab(Vector3 arg) => ywz = arg;
+  set brg(Vector3 arg) => zxy = arg;
+  set bra(Vector3 arg) => zxw = arg;
+  set bgr(Vector3 arg) => zyx = arg;
+  set bga(Vector3 arg) => zyw = arg;
+  set bar(Vector3 arg) => zwx = arg;
+  set bag(Vector3 arg) => zwy = arg;
+  set arg(Vector3 arg) => wxy = arg;
+  set arb(Vector3 arg) => wxz = arg;
+  set agr(Vector3 arg) => wyx = arg;
+  set agb(Vector3 arg) => wyz = arg;
+  set abr(Vector3 arg) => wzx = arg;
+  set abg(Vector3 arg) => wzy = arg;
+  set rgba(Vector4 arg) => xyzw = arg;
+  set rgab(Vector4 arg) => xywz = arg;
+  set rbga(Vector4 arg) => xzyw = arg;
+  set rbag(Vector4 arg) => xzwy = arg;
+  set ragb(Vector4 arg) => xwyz = arg;
+  set rabg(Vector4 arg) => xwzy = arg;
+  set grba(Vector4 arg) => yxzw = arg;
+  set grab(Vector4 arg) => yxwz = arg;
+  set gbra(Vector4 arg) => yzxw = arg;
+  set gbar(Vector4 arg) => yzwx = arg;
+  set garb(Vector4 arg) => ywxz = arg;
+  set gabr(Vector4 arg) => ywzx = arg;
+  set brga(Vector4 arg) => zxyw = arg;
+  set brag(Vector4 arg) => zxwy = arg;
+  set bgra(Vector4 arg) => zyxw = arg;
+  set bgar(Vector4 arg) => zywx = arg;
+  set barg(Vector4 arg) => zwxy = arg;
+  set bagr(Vector4 arg) => zwyx = arg;
+  set argb(Vector4 arg) => wxyz = arg;
+  set arbg(Vector4 arg) => wxzy = arg;
+  set agrb(Vector4 arg) => wyxz = arg;
+  set agbr(Vector4 arg) => wyzx = arg;
+  set abrg(Vector4 arg) => wzxy = arg;
+  set abgr(Vector4 arg) => wzyx = arg;
+  set st(Vector2 arg) => xy = arg;
+  set sp(Vector2 arg) => xz = arg;
+  set sq(Vector2 arg) => xw = arg;
+  set ts(Vector2 arg) => yx = arg;
+  set tp(Vector2 arg) => yz = arg;
+  set tq(Vector2 arg) => yw = arg;
+  set ps(Vector2 arg) => zx = arg;
+  set pt(Vector2 arg) => zy = arg;
+  set pq(Vector2 arg) => zw = arg;
+  set qs(Vector2 arg) => wx = arg;
+  set qt(Vector2 arg) => wy = arg;
+  set qp(Vector2 arg) => wz = arg;
+  set stp(Vector3 arg) => xyz = arg;
+  set stq(Vector3 arg) => xyw = arg;
+  set spt(Vector3 arg) => xzy = arg;
+  set spq(Vector3 arg) => xzw = arg;
+  set sqt(Vector3 arg) => xwy = arg;
+  set sqp(Vector3 arg) => xwz = arg;
+  set tsp(Vector3 arg) => yxz = arg;
+  set tsq(Vector3 arg) => yxw = arg;
+  set tps(Vector3 arg) => yzx = arg;
+  set tpq(Vector3 arg) => yzw = arg;
+  set tqs(Vector3 arg) => ywx = arg;
+  set tqp(Vector3 arg) => ywz = arg;
+  set pst(Vector3 arg) => zxy = arg;
+  set psq(Vector3 arg) => zxw = arg;
+  set pts(Vector3 arg) => zyx = arg;
+  set ptq(Vector3 arg) => zyw = arg;
+  set pqs(Vector3 arg) => zwx = arg;
+  set pqt(Vector3 arg) => zwy = arg;
+  set qst(Vector3 arg) => wxy = arg;
+  set qsp(Vector3 arg) => wxz = arg;
+  set qts(Vector3 arg) => wyx = arg;
+  set qtp(Vector3 arg) => wyz = arg;
+  set qps(Vector3 arg) => wzx = arg;
+  set qpt(Vector3 arg) => wzy = arg;
+  set stpq(Vector4 arg) => xyzw = arg;
+  set stqp(Vector4 arg) => xywz = arg;
+  set sptq(Vector4 arg) => xzyw = arg;
+  set spqt(Vector4 arg) => xzwy = arg;
+  set sqtp(Vector4 arg) => xwyz = arg;
+  set sqpt(Vector4 arg) => xwzy = arg;
+  set tspq(Vector4 arg) => yxzw = arg;
+  set tsqp(Vector4 arg) => yxwz = arg;
+  set tpsq(Vector4 arg) => yzxw = arg;
+  set tpqs(Vector4 arg) => yzwx = arg;
+  set tqsp(Vector4 arg) => ywxz = arg;
+  set tqps(Vector4 arg) => ywzx = arg;
+  set pstq(Vector4 arg) => zxyw = arg;
+  set psqt(Vector4 arg) => zxwy = arg;
+  set ptsq(Vector4 arg) => zyxw = arg;
+  set ptqs(Vector4 arg) => zywx = arg;
+  set pqst(Vector4 arg) => zwxy = arg;
+  set pqts(Vector4 arg) => zwyx = arg;
+  set qstp(Vector4 arg) => wxyz = arg;
+  set qspt(Vector4 arg) => wxzy = arg;
+  set qtsp(Vector4 arg) => wyxz = arg;
+  set qtps(Vector4 arg) => wyzx = arg;
+  set qpst(Vector4 arg) => wzxy = arg;
+  set qpts(Vector4 arg) => wzyx = arg;
+  Vector2 get xx => new Vector2(_storage[0], _storage[0]);
+  Vector2 get xy => new Vector2(_storage[0], _storage[1]);
+  Vector2 get xz => new Vector2(_storage[0], _storage[2]);
+  Vector2 get xw => new Vector2(_storage[0], _storage[3]);
+  Vector2 get yx => new Vector2(_storage[1], _storage[0]);
+  Vector2 get yy => new Vector2(_storage[1], _storage[1]);
+  Vector2 get yz => new Vector2(_storage[1], _storage[2]);
+  Vector2 get yw => new Vector2(_storage[1], _storage[3]);
+  Vector2 get zx => new Vector2(_storage[2], _storage[0]);
+  Vector2 get zy => new Vector2(_storage[2], _storage[1]);
+  Vector2 get zz => new Vector2(_storage[2], _storage[2]);
+  Vector2 get zw => new Vector2(_storage[2], _storage[3]);
+  Vector2 get wx => new Vector2(_storage[3], _storage[0]);
+  Vector2 get wy => new Vector2(_storage[3], _storage[1]);
+  Vector2 get wz => new Vector2(_storage[3], _storage[2]);
+  Vector2 get ww => new Vector2(_storage[3], _storage[3]);
+  Vector3 get xxx => new Vector3(_storage[0], _storage[0], _storage[0]);
+  Vector3 get xxy => new Vector3(_storage[0], _storage[0], _storage[1]);
+  Vector3 get xxz => new Vector3(_storage[0], _storage[0], _storage[2]);
+  Vector3 get xxw => new Vector3(_storage[0], _storage[0], _storage[3]);
+  Vector3 get xyx => new Vector3(_storage[0], _storage[1], _storage[0]);
+  Vector3 get xyy => new Vector3(_storage[0], _storage[1], _storage[1]);
+  Vector3 get xyz => new Vector3(_storage[0], _storage[1], _storage[2]);
+  Vector3 get xyw => new Vector3(_storage[0], _storage[1], _storage[3]);
+  Vector3 get xzx => new Vector3(_storage[0], _storage[2], _storage[0]);
+  Vector3 get xzy => new Vector3(_storage[0], _storage[2], _storage[1]);
+  Vector3 get xzz => new Vector3(_storage[0], _storage[2], _storage[2]);
+  Vector3 get xzw => new Vector3(_storage[0], _storage[2], _storage[3]);
+  Vector3 get xwx => new Vector3(_storage[0], _storage[3], _storage[0]);
+  Vector3 get xwy => new Vector3(_storage[0], _storage[3], _storage[1]);
+  Vector3 get xwz => new Vector3(_storage[0], _storage[3], _storage[2]);
+  Vector3 get xww => new Vector3(_storage[0], _storage[3], _storage[3]);
+  Vector3 get yxx => new Vector3(_storage[1], _storage[0], _storage[0]);
+  Vector3 get yxy => new Vector3(_storage[1], _storage[0], _storage[1]);
+  Vector3 get yxz => new Vector3(_storage[1], _storage[0], _storage[2]);
+  Vector3 get yxw => new Vector3(_storage[1], _storage[0], _storage[3]);
+  Vector3 get yyx => new Vector3(_storage[1], _storage[1], _storage[0]);
+  Vector3 get yyy => new Vector3(_storage[1], _storage[1], _storage[1]);
+  Vector3 get yyz => new Vector3(_storage[1], _storage[1], _storage[2]);
+  Vector3 get yyw => new Vector3(_storage[1], _storage[1], _storage[3]);
+  Vector3 get yzx => new Vector3(_storage[1], _storage[2], _storage[0]);
+  Vector3 get yzy => new Vector3(_storage[1], _storage[2], _storage[1]);
+  Vector3 get yzz => new Vector3(_storage[1], _storage[2], _storage[2]);
+  Vector3 get yzw => new Vector3(_storage[1], _storage[2], _storage[3]);
+  Vector3 get ywx => new Vector3(_storage[1], _storage[3], _storage[0]);
+  Vector3 get ywy => new Vector3(_storage[1], _storage[3], _storage[1]);
+  Vector3 get ywz => new Vector3(_storage[1], _storage[3], _storage[2]);
+  Vector3 get yww => new Vector3(_storage[1], _storage[3], _storage[3]);
+  Vector3 get zxx => new Vector3(_storage[2], _storage[0], _storage[0]);
+  Vector3 get zxy => new Vector3(_storage[2], _storage[0], _storage[1]);
+  Vector3 get zxz => new Vector3(_storage[2], _storage[0], _storage[2]);
+  Vector3 get zxw => new Vector3(_storage[2], _storage[0], _storage[3]);
+  Vector3 get zyx => new Vector3(_storage[2], _storage[1], _storage[0]);
+  Vector3 get zyy => new Vector3(_storage[2], _storage[1], _storage[1]);
+  Vector3 get zyz => new Vector3(_storage[2], _storage[1], _storage[2]);
+  Vector3 get zyw => new Vector3(_storage[2], _storage[1], _storage[3]);
+  Vector3 get zzx => new Vector3(_storage[2], _storage[2], _storage[0]);
+  Vector3 get zzy => new Vector3(_storage[2], _storage[2], _storage[1]);
+  Vector3 get zzz => new Vector3(_storage[2], _storage[2], _storage[2]);
+  Vector3 get zzw => new Vector3(_storage[2], _storage[2], _storage[3]);
+  Vector3 get zwx => new Vector3(_storage[2], _storage[3], _storage[0]);
+  Vector3 get zwy => new Vector3(_storage[2], _storage[3], _storage[1]);
+  Vector3 get zwz => new Vector3(_storage[2], _storage[3], _storage[2]);
+  Vector3 get zww => new Vector3(_storage[2], _storage[3], _storage[3]);
+  Vector3 get wxx => new Vector3(_storage[3], _storage[0], _storage[0]);
+  Vector3 get wxy => new Vector3(_storage[3], _storage[0], _storage[1]);
+  Vector3 get wxz => new Vector3(_storage[3], _storage[0], _storage[2]);
+  Vector3 get wxw => new Vector3(_storage[3], _storage[0], _storage[3]);
+  Vector3 get wyx => new Vector3(_storage[3], _storage[1], _storage[0]);
+  Vector3 get wyy => new Vector3(_storage[3], _storage[1], _storage[1]);
+  Vector3 get wyz => new Vector3(_storage[3], _storage[1], _storage[2]);
+  Vector3 get wyw => new Vector3(_storage[3], _storage[1], _storage[3]);
+  Vector3 get wzx => new Vector3(_storage[3], _storage[2], _storage[0]);
+  Vector3 get wzy => new Vector3(_storage[3], _storage[2], _storage[1]);
+  Vector3 get wzz => new Vector3(_storage[3], _storage[2], _storage[2]);
+  Vector3 get wzw => new Vector3(_storage[3], _storage[2], _storage[3]);
+  Vector3 get wwx => new Vector3(_storage[3], _storage[3], _storage[0]);
+  Vector3 get wwy => new Vector3(_storage[3], _storage[3], _storage[1]);
+  Vector3 get wwz => new Vector3(_storage[3], _storage[3], _storage[2]);
+  Vector3 get www => new Vector3(_storage[3], _storage[3], _storage[3]);
   Vector4 get xxxx =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[0]);
   Vector4 get xxxy =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[1]);
   Vector4 get xxxz =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[2]);
   Vector4 get xxxw =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[3]);
   Vector4 get xxyx =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[0]);
   Vector4 get xxyy =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[1]);
   Vector4 get xxyz =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[2]);
   Vector4 get xxyw =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[3]);
   Vector4 get xxzx =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[0]);
   Vector4 get xxzy =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[1]);
   Vector4 get xxzz =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[2]);
   Vector4 get xxzw =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[3]);
   Vector4 get xxwx =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[0]);
   Vector4 get xxwy =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[1]);
   Vector4 get xxwz =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[2]);
   Vector4 get xxww =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[3]);
   Vector4 get xyxx =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[0]);
   Vector4 get xyxy =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[1]);
   Vector4 get xyxz =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[2]);
   Vector4 get xyxw =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[3]);
   Vector4 get xyyx =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[0]);
   Vector4 get xyyy =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[1]);
   Vector4 get xyyz =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[2]);
   Vector4 get xyyw =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[3]);
   Vector4 get xyzx =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[0]);
   Vector4 get xyzy =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[1]);
   Vector4 get xyzz =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[2]);
   Vector4 get xyzw =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[3]);
   Vector4 get xywx =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[0]);
   Vector4 get xywy =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[1]);
   Vector4 get xywz =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[2]);
   Vector4 get xyww =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[3]);
   Vector4 get xzxx =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[0]);
   Vector4 get xzxy =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[1]);
   Vector4 get xzxz =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[2]);
   Vector4 get xzxw =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[3]);
   Vector4 get xzyx =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[0]);
   Vector4 get xzyy =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[1]);
   Vector4 get xzyz =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[2]);
   Vector4 get xzyw =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[3]);
   Vector4 get xzzx =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[0]);
   Vector4 get xzzy =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[1]);
   Vector4 get xzzz =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[2]);
   Vector4 get xzzw =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[3]);
   Vector4 get xzwx =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[0]);
   Vector4 get xzwy =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[1]);
   Vector4 get xzwz =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[2]);
   Vector4 get xzww =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[3]);
   Vector4 get xwxx =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[0]);
   Vector4 get xwxy =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[1]);
   Vector4 get xwxz =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[2]);
   Vector4 get xwxw =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[3]);
   Vector4 get xwyx =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[0]);
   Vector4 get xwyy =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[1]);
   Vector4 get xwyz =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[2]);
   Vector4 get xwyw =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[3]);
   Vector4 get xwzx =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[0]);
   Vector4 get xwzy =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[1]);
   Vector4 get xwzz =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[2]);
   Vector4 get xwzw =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[3]);
   Vector4 get xwwx =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[0]);
   Vector4 get xwwy =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[1]);
   Vector4 get xwwz =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[2]);
   Vector4 get xwww =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[3]);
   Vector4 get yxxx =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[0]);
   Vector4 get yxxy =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[1]);
   Vector4 get yxxz =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[2]);
   Vector4 get yxxw =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[3]);
   Vector4 get yxyx =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[0]);
   Vector4 get yxyy =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[1]);
   Vector4 get yxyz =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[2]);
   Vector4 get yxyw =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[3]);
   Vector4 get yxzx =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[0]);
   Vector4 get yxzy =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[1]);
   Vector4 get yxzz =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[2]);
   Vector4 get yxzw =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[3]);
   Vector4 get yxwx =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[0]);
   Vector4 get yxwy =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[1]);
   Vector4 get yxwz =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[2]);
   Vector4 get yxww =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[3]);
   Vector4 get yyxx =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[0]);
   Vector4 get yyxy =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[1]);
   Vector4 get yyxz =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[2]);
   Vector4 get yyxw =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[3]);
   Vector4 get yyyx =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[0]);
   Vector4 get yyyy =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[1]);
   Vector4 get yyyz =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[2]);
   Vector4 get yyyw =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[3]);
   Vector4 get yyzx =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[0]);
   Vector4 get yyzy =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[1]);
   Vector4 get yyzz =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[2]);
   Vector4 get yyzw =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[3]);
   Vector4 get yywx =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[0]);
   Vector4 get yywy =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[1]);
   Vector4 get yywz =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[2]);
   Vector4 get yyww =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[3]);
   Vector4 get yzxx =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[0]);
   Vector4 get yzxy =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[1]);
   Vector4 get yzxz =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[2]);
   Vector4 get yzxw =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[3]);
   Vector4 get yzyx =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[0]);
   Vector4 get yzyy =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[1]);
   Vector4 get yzyz =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[2]);
   Vector4 get yzyw =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[3]);
   Vector4 get yzzx =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[0]);
   Vector4 get yzzy =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[1]);
   Vector4 get yzzz =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[2]);
   Vector4 get yzzw =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[3]);
   Vector4 get yzwx =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[0]);
   Vector4 get yzwy =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[1]);
   Vector4 get yzwz =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[2]);
   Vector4 get yzww =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[3]);
   Vector4 get ywxx =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[0]);
   Vector4 get ywxy =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[1]);
   Vector4 get ywxz =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[2]);
   Vector4 get ywxw =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[3]);
   Vector4 get ywyx =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[0]);
   Vector4 get ywyy =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[1]);
   Vector4 get ywyz =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[2]);
   Vector4 get ywyw =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[3]);
   Vector4 get ywzx =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[0]);
   Vector4 get ywzy =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[1]);
   Vector4 get ywzz =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[2]);
   Vector4 get ywzw =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[3]);
   Vector4 get ywwx =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[0]);
   Vector4 get ywwy =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[1]);
   Vector4 get ywwz =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[2]);
   Vector4 get ywww =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[3]);
   Vector4 get zxxx =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[0]);
   Vector4 get zxxy =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[1]);
   Vector4 get zxxz =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[2]);
   Vector4 get zxxw =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[3]);
   Vector4 get zxyx =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[0]);
   Vector4 get zxyy =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[1]);
   Vector4 get zxyz =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[2]);
   Vector4 get zxyw =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[3]);
   Vector4 get zxzx =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[0]);
   Vector4 get zxzy =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[1]);
   Vector4 get zxzz =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[2]);
   Vector4 get zxzw =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[3]);
   Vector4 get zxwx =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[0]);
   Vector4 get zxwy =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[1]);
   Vector4 get zxwz =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[2]);
   Vector4 get zxww =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[3]);
   Vector4 get zyxx =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[0]);
   Vector4 get zyxy =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[1]);
   Vector4 get zyxz =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[2]);
   Vector4 get zyxw =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[3]);
   Vector4 get zyyx =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[0]);
   Vector4 get zyyy =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[1]);
   Vector4 get zyyz =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[2]);
   Vector4 get zyyw =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[3]);
   Vector4 get zyzx =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[0]);
   Vector4 get zyzy =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[1]);
   Vector4 get zyzz =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[2]);
   Vector4 get zyzw =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[3]);
   Vector4 get zywx =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[0]);
   Vector4 get zywy =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[1]);
   Vector4 get zywz =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[2]);
   Vector4 get zyww =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[3]);
   Vector4 get zzxx =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[0]);
   Vector4 get zzxy =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[1]);
   Vector4 get zzxz =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[2]);
   Vector4 get zzxw =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[3]);
   Vector4 get zzyx =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[0]);
   Vector4 get zzyy =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[1]);
   Vector4 get zzyz =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[2]);
   Vector4 get zzyw =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[3]);
   Vector4 get zzzx =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[0]);
   Vector4 get zzzy =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[1]);
   Vector4 get zzzz =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[2]);
   Vector4 get zzzw =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[3]);
   Vector4 get zzwx =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[0]);
   Vector4 get zzwy =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[1]);
   Vector4 get zzwz =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[2]);
   Vector4 get zzww =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[3]);
   Vector4 get zwxx =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[0]);
   Vector4 get zwxy =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[1]);
   Vector4 get zwxz =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[2]);
   Vector4 get zwxw =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[3]);
   Vector4 get zwyx =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[0]);
   Vector4 get zwyy =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[1]);
   Vector4 get zwyz =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[2]);
   Vector4 get zwyw =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[3]);
   Vector4 get zwzx =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[0]);
   Vector4 get zwzy =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[1]);
   Vector4 get zwzz =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[2]);
   Vector4 get zwzw =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[3]);
   Vector4 get zwwx =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[0]);
   Vector4 get zwwy =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[1]);
   Vector4 get zwwz =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[2]);
   Vector4 get zwww =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[3]);
   Vector4 get wxxx =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[0]);
   Vector4 get wxxy =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[1]);
   Vector4 get wxxz =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[2]);
   Vector4 get wxxw =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[3]);
   Vector4 get wxyx =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[0]);
   Vector4 get wxyy =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[1]);
   Vector4 get wxyz =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[2]);
   Vector4 get wxyw =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[3]);
   Vector4 get wxzx =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[0]);
   Vector4 get wxzy =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[1]);
   Vector4 get wxzz =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[2]);
   Vector4 get wxzw =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[3]);
   Vector4 get wxwx =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[0]);
   Vector4 get wxwy =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[1]);
   Vector4 get wxwz =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[2]);
   Vector4 get wxww =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[3]);
   Vector4 get wyxx =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[0]);
   Vector4 get wyxy =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[1]);
   Vector4 get wyxz =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[2]);
   Vector4 get wyxw =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[3]);
   Vector4 get wyyx =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[0]);
   Vector4 get wyyy =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[1]);
   Vector4 get wyyz =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[2]);
   Vector4 get wyyw =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[3]);
   Vector4 get wyzx =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[0]);
   Vector4 get wyzy =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[1]);
   Vector4 get wyzz =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[2]);
   Vector4 get wyzw =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[3]);
   Vector4 get wywx =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[0]);
   Vector4 get wywy =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[1]);
   Vector4 get wywz =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[2]);
   Vector4 get wyww =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[3]);
   Vector4 get wzxx =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[0]);
   Vector4 get wzxy =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[1]);
   Vector4 get wzxz =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[2]);
   Vector4 get wzxw =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[3]);
   Vector4 get wzyx =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[0]);
   Vector4 get wzyy =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[1]);
   Vector4 get wzyz =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[2]);
   Vector4 get wzyw =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[3]);
   Vector4 get wzzx =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[0]);
   Vector4 get wzzy =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[1]);
   Vector4 get wzzz =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[2]);
   Vector4 get wzzw =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[3]);
   Vector4 get wzwx =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[0]);
   Vector4 get wzwy =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[1]);
   Vector4 get wzwz =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[2]);
   Vector4 get wzww =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[3]);
   Vector4 get wwxx =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[0]);
   Vector4 get wwxy =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[1]);
   Vector4 get wwxz =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[2]);
   Vector4 get wwxw =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[3]);
   Vector4 get wwyx =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[0]);
   Vector4 get wwyy =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[1]);
   Vector4 get wwyz =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[2]);
   Vector4 get wwyw =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[3]);
   Vector4 get wwzx =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[0]);
   Vector4 get wwzy =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[1]);
   Vector4 get wwzz =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[2]);
   Vector4 get wwzw =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[3]);
   Vector4 get wwwx =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[0]);
   Vector4 get wwwy =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[1]);
   Vector4 get wwwz =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[2]);
   Vector4 get wwww =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
-  double get r => storage[0];
-  double get g => storage[1];
-  double get b => storage[2];
-  double get a => storage[3];
-  double get s => storage[0];
-  double get t => storage[1];
-  double get p => storage[2];
-  double get q => storage[3];
-  double get x => storage[0];
-  double get y => storage[1];
-  double get z => storage[2];
-  double get w => storage[3];
-  Vector2 get rr => new Vector2(storage[0], storage[0]);
-  Vector2 get rg => new Vector2(storage[0], storage[1]);
-  Vector2 get rb => new Vector2(storage[0], storage[2]);
-  Vector2 get ra => new Vector2(storage[0], storage[3]);
-  Vector2 get gr => new Vector2(storage[1], storage[0]);
-  Vector2 get gg => new Vector2(storage[1], storage[1]);
-  Vector2 get gb => new Vector2(storage[1], storage[2]);
-  Vector2 get ga => new Vector2(storage[1], storage[3]);
-  Vector2 get br => new Vector2(storage[2], storage[0]);
-  Vector2 get bg => new Vector2(storage[2], storage[1]);
-  Vector2 get bb => new Vector2(storage[2], storage[2]);
-  Vector2 get ba => new Vector2(storage[2], storage[3]);
-  Vector2 get ar => new Vector2(storage[3], storage[0]);
-  Vector2 get ag => new Vector2(storage[3], storage[1]);
-  Vector2 get ab => new Vector2(storage[3], storage[2]);
-  Vector2 get aa => new Vector2(storage[3], storage[3]);
-  Vector3 get rrr => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get rrg => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get rrb => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get rra => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get rgr => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get rgg => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get rgb => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get rga => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get rbr => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get rbg => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get rbb => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get rba => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get rar => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get rag => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get rab => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get raa => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get grr => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get grg => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get grb => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get gra => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get ggr => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ggg => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get ggb => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get gga => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get gbr => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get gbg => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get gbb => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get gba => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get gar => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get gag => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get gab => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get gaa => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get brr => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get brg => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get brb => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get bra => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get bgr => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get bgg => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get bgb => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get bga => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get bbr => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get bbg => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get bbb => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get bba => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get bar => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get bag => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get bab => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get baa => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get arr => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get arg => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get arb => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get ara => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get agr => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get agg => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get agb => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get aga => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get abr => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get abg => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get abb => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get aba => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get aar => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get aag => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get aab => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get aaa => new Vector3(storage[3], storage[3], storage[3]);
-  Vector4 get rrrr =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get rrrg =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get rrrb =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
-  Vector4 get rrra =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
-  Vector4 get rrgr =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get rrgg =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get rrgb =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
-  Vector4 get rrga =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
-  Vector4 get rrbr =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
-  Vector4 get rrbg =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
-  Vector4 get rrbb =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
-  Vector4 get rrba =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
-  Vector4 get rrar =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
-  Vector4 get rrag =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
-  Vector4 get rrab =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
-  Vector4 get rraa =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
-  Vector4 get rgrr =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get rgrg =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get rgrb =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
-  Vector4 get rgra =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
-  Vector4 get rggr =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get rggg =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get rggb =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
-  Vector4 get rgga =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
-  Vector4 get rgbr =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
-  Vector4 get rgbg =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
-  Vector4 get rgbb =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
-  Vector4 get rgba =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
-  Vector4 get rgar =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
-  Vector4 get rgag =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
-  Vector4 get rgab =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
-  Vector4 get rgaa =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
-  Vector4 get rbrr =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
-  Vector4 get rbrg =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
-  Vector4 get rbrb =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
-  Vector4 get rbra =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
-  Vector4 get rbgr =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
-  Vector4 get rbgg =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
-  Vector4 get rbgb =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
-  Vector4 get rbga =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
-  Vector4 get rbbr =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
-  Vector4 get rbbg =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
-  Vector4 get rbbb =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
-  Vector4 get rbba =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
-  Vector4 get rbar =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
-  Vector4 get rbag =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
-  Vector4 get rbab =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
-  Vector4 get rbaa =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
-  Vector4 get rarr =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
-  Vector4 get rarg =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
-  Vector4 get rarb =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
-  Vector4 get rara =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
-  Vector4 get ragr =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
-  Vector4 get ragg =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
-  Vector4 get ragb =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
-  Vector4 get raga =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
-  Vector4 get rabr =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
-  Vector4 get rabg =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
-  Vector4 get rabb =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
-  Vector4 get raba =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
-  Vector4 get raar =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
-  Vector4 get raag =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
-  Vector4 get raab =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
-  Vector4 get raaa =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
-  Vector4 get grrr =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get grrg =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get grrb =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
-  Vector4 get grra =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
-  Vector4 get grgr =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get grgg =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get grgb =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
-  Vector4 get grga =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
-  Vector4 get grbr =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
-  Vector4 get grbg =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
-  Vector4 get grbb =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
-  Vector4 get grba =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
-  Vector4 get grar =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
-  Vector4 get grag =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
-  Vector4 get grab =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
-  Vector4 get graa =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
-  Vector4 get ggrr =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ggrg =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ggrb =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
-  Vector4 get ggra =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
-  Vector4 get gggr =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get gggg =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector4 get gggb =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
-  Vector4 get ggga =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
-  Vector4 get ggbr =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
-  Vector4 get ggbg =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
-  Vector4 get ggbb =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
-  Vector4 get ggba =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
-  Vector4 get ggar =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
-  Vector4 get ggag =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
-  Vector4 get ggab =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
-  Vector4 get ggaa =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
-  Vector4 get gbrr =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
-  Vector4 get gbrg =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
-  Vector4 get gbrb =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
-  Vector4 get gbra =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
-  Vector4 get gbgr =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
-  Vector4 get gbgg =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
-  Vector4 get gbgb =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
-  Vector4 get gbga =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
-  Vector4 get gbbr =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
-  Vector4 get gbbg =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
-  Vector4 get gbbb =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
-  Vector4 get gbba =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
-  Vector4 get gbar =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
-  Vector4 get gbag =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
-  Vector4 get gbab =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
-  Vector4 get gbaa =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
-  Vector4 get garr =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
-  Vector4 get garg =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
-  Vector4 get garb =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
-  Vector4 get gara =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
-  Vector4 get gagr =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
-  Vector4 get gagg =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
-  Vector4 get gagb =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
-  Vector4 get gaga =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
-  Vector4 get gabr =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
-  Vector4 get gabg =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
-  Vector4 get gabb =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
-  Vector4 get gaba =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
-  Vector4 get gaar =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
-  Vector4 get gaag =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
-  Vector4 get gaab =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
-  Vector4 get gaaa =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
-  Vector4 get brrr =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
-  Vector4 get brrg =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
-  Vector4 get brrb =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
-  Vector4 get brra =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
-  Vector4 get brgr =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
-  Vector4 get brgg =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
-  Vector4 get brgb =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
-  Vector4 get brga =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
-  Vector4 get brbr =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
-  Vector4 get brbg =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
-  Vector4 get brbb =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
-  Vector4 get brba =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
-  Vector4 get brar =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
-  Vector4 get brag =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
-  Vector4 get brab =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
-  Vector4 get braa =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
-  Vector4 get bgrr =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
-  Vector4 get bgrg =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
-  Vector4 get bgrb =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
-  Vector4 get bgra =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
-  Vector4 get bggr =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
-  Vector4 get bggg =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
-  Vector4 get bggb =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
-  Vector4 get bgga =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
-  Vector4 get bgbr =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
-  Vector4 get bgbg =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
-  Vector4 get bgbb =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
-  Vector4 get bgba =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
-  Vector4 get bgar =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
-  Vector4 get bgag =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
-  Vector4 get bgab =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
-  Vector4 get bgaa =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
-  Vector4 get bbrr =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
-  Vector4 get bbrg =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
-  Vector4 get bbrb =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
-  Vector4 get bbra =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
-  Vector4 get bbgr =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
-  Vector4 get bbgg =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
-  Vector4 get bbgb =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
-  Vector4 get bbga =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
-  Vector4 get bbbr =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
-  Vector4 get bbbg =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
-  Vector4 get bbbb =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
-  Vector4 get bbba =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
-  Vector4 get bbar =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
-  Vector4 get bbag =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
-  Vector4 get bbab =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
-  Vector4 get bbaa =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
-  Vector4 get barr =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
-  Vector4 get barg =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
-  Vector4 get barb =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
-  Vector4 get bara =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
-  Vector4 get bagr =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
-  Vector4 get bagg =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
-  Vector4 get bagb =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
-  Vector4 get baga =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
-  Vector4 get babr =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
-  Vector4 get babg =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
-  Vector4 get babb =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
-  Vector4 get baba =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
-  Vector4 get baar =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
-  Vector4 get baag =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
-  Vector4 get baab =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
-  Vector4 get baaa =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
-  Vector4 get arrr =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
-  Vector4 get arrg =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
-  Vector4 get arrb =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
-  Vector4 get arra =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
-  Vector4 get argr =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
-  Vector4 get argg =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
-  Vector4 get argb =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
-  Vector4 get arga =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
-  Vector4 get arbr =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
-  Vector4 get arbg =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
-  Vector4 get arbb =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
-  Vector4 get arba =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
-  Vector4 get arar =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
-  Vector4 get arag =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
-  Vector4 get arab =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
-  Vector4 get araa =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
-  Vector4 get agrr =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
-  Vector4 get agrg =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
-  Vector4 get agrb =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
-  Vector4 get agra =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
-  Vector4 get aggr =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
-  Vector4 get aggg =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
-  Vector4 get aggb =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
-  Vector4 get agga =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
-  Vector4 get agbr =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
-  Vector4 get agbg =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
-  Vector4 get agbb =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
-  Vector4 get agba =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
-  Vector4 get agar =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
-  Vector4 get agag =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
-  Vector4 get agab =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
-  Vector4 get agaa =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
-  Vector4 get abrr =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
-  Vector4 get abrg =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
-  Vector4 get abrb =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
-  Vector4 get abra =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
-  Vector4 get abgr =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
-  Vector4 get abgg =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
-  Vector4 get abgb =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
-  Vector4 get abga =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
-  Vector4 get abbr =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
-  Vector4 get abbg =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
-  Vector4 get abbb =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
-  Vector4 get abba =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
-  Vector4 get abar =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
-  Vector4 get abag =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
-  Vector4 get abab =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
-  Vector4 get abaa =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
-  Vector4 get aarr =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
-  Vector4 get aarg =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
-  Vector4 get aarb =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
-  Vector4 get aara =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
-  Vector4 get aagr =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
-  Vector4 get aagg =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
-  Vector4 get aagb =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
-  Vector4 get aaga =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
-  Vector4 get aabr =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
-  Vector4 get aabg =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
-  Vector4 get aabb =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
-  Vector4 get aaba =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
-  Vector4 get aaar =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
-  Vector4 get aaag =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
-  Vector4 get aaab =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
-  Vector4 get aaaa =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
-  Vector2 get ss => new Vector2(storage[0], storage[0]);
-  Vector2 get st => new Vector2(storage[0], storage[1]);
-  Vector2 get sp => new Vector2(storage[0], storage[2]);
-  Vector2 get sq => new Vector2(storage[0], storage[3]);
-  Vector2 get ts => new Vector2(storage[1], storage[0]);
-  Vector2 get tt => new Vector2(storage[1], storage[1]);
-  Vector2 get tp => new Vector2(storage[1], storage[2]);
-  Vector2 get tq => new Vector2(storage[1], storage[3]);
-  Vector2 get ps => new Vector2(storage[2], storage[0]);
-  Vector2 get pt => new Vector2(storage[2], storage[1]);
-  Vector2 get pp => new Vector2(storage[2], storage[2]);
-  Vector2 get pq => new Vector2(storage[2], storage[3]);
-  Vector2 get qs => new Vector2(storage[3], storage[0]);
-  Vector2 get qt => new Vector2(storage[3], storage[1]);
-  Vector2 get qp => new Vector2(storage[3], storage[2]);
-  Vector2 get qq => new Vector2(storage[3], storage[3]);
-  Vector3 get sss => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get sst => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get ssp => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get ssq => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get sts => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get stt => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get stp => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get stq => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get sps => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get spt => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get spp => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get spq => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get sqs => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get sqt => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get sqp => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get sqq => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get tss => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get tst => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get tsp => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get tsq => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get tts => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ttt => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get ttp => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get ttq => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get tps => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get tpt => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get tpp => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get tpq => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get tqs => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get tqt => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get tqp => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get tqq => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get pss => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get pst => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get psp => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get psq => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get pts => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get ptt => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get ptp => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get ptq => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get pps => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get ppt => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get ppp => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get ppq => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get pqs => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get pqt => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get pqp => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get pqq => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get qss => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get qst => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get qsp => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get qsq => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get qts => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get qtt => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get qtp => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get qtq => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get qps => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get qpt => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get qpp => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get qpq => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get qqs => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get qqt => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get qqp => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get qqq => new Vector3(storage[3], storage[3], storage[3]);
-  Vector4 get ssss =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get ssst =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get sssp =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
-  Vector4 get sssq =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
-  Vector4 get ssts =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get sstt =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get sstp =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
-  Vector4 get sstq =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
-  Vector4 get ssps =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
-  Vector4 get sspt =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
-  Vector4 get sspp =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
-  Vector4 get sspq =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
-  Vector4 get ssqs =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
-  Vector4 get ssqt =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
-  Vector4 get ssqp =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
-  Vector4 get ssqq =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
-  Vector4 get stss =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get stst =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get stsp =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
-  Vector4 get stsq =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
-  Vector4 get stts =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get sttt =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get sttp =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
-  Vector4 get sttq =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
-  Vector4 get stps =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
-  Vector4 get stpt =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
-  Vector4 get stpp =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
-  Vector4 get stpq =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
-  Vector4 get stqs =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
-  Vector4 get stqt =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
-  Vector4 get stqp =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
-  Vector4 get stqq =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
-  Vector4 get spss =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
-  Vector4 get spst =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
-  Vector4 get spsp =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
-  Vector4 get spsq =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
-  Vector4 get spts =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
-  Vector4 get sptt =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
-  Vector4 get sptp =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
-  Vector4 get sptq =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
-  Vector4 get spps =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
-  Vector4 get sppt =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
-  Vector4 get sppp =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
-  Vector4 get sppq =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
-  Vector4 get spqs =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
-  Vector4 get spqt =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
-  Vector4 get spqp =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
-  Vector4 get spqq =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
-  Vector4 get sqss =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
-  Vector4 get sqst =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
-  Vector4 get sqsp =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
-  Vector4 get sqsq =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
-  Vector4 get sqts =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
-  Vector4 get sqtt =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
-  Vector4 get sqtp =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
-  Vector4 get sqtq =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
-  Vector4 get sqps =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
-  Vector4 get sqpt =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
-  Vector4 get sqpp =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
-  Vector4 get sqpq =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
-  Vector4 get sqqs =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
-  Vector4 get sqqt =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
-  Vector4 get sqqp =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
-  Vector4 get sqqq =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
-  Vector4 get tsss =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get tsst =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get tssp =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
-  Vector4 get tssq =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
-  Vector4 get tsts =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get tstt =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get tstp =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
-  Vector4 get tstq =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
-  Vector4 get tsps =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
-  Vector4 get tspt =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
-  Vector4 get tspp =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
-  Vector4 get tspq =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
-  Vector4 get tsqs =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
-  Vector4 get tsqt =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
-  Vector4 get tsqp =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
-  Vector4 get tsqq =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
-  Vector4 get ttss =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ttst =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ttsp =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
-  Vector4 get ttsq =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
-  Vector4 get ttts =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get tttt =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector4 get tttp =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
-  Vector4 get tttq =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
-  Vector4 get ttps =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
-  Vector4 get ttpt =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
-  Vector4 get ttpp =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
-  Vector4 get ttpq =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
-  Vector4 get ttqs =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
-  Vector4 get ttqt =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
-  Vector4 get ttqp =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
-  Vector4 get ttqq =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
-  Vector4 get tpss =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
-  Vector4 get tpst =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
-  Vector4 get tpsp =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
-  Vector4 get tpsq =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
-  Vector4 get tpts =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
-  Vector4 get tptt =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
-  Vector4 get tptp =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
-  Vector4 get tptq =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
-  Vector4 get tpps =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
-  Vector4 get tppt =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
-  Vector4 get tppp =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
-  Vector4 get tppq =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
-  Vector4 get tpqs =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
-  Vector4 get tpqt =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
-  Vector4 get tpqp =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
-  Vector4 get tpqq =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
-  Vector4 get tqss =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
-  Vector4 get tqst =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
-  Vector4 get tqsp =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
-  Vector4 get tqsq =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
-  Vector4 get tqts =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
-  Vector4 get tqtt =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
-  Vector4 get tqtp =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
-  Vector4 get tqtq =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
-  Vector4 get tqps =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
-  Vector4 get tqpt =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
-  Vector4 get tqpp =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
-  Vector4 get tqpq =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
-  Vector4 get tqqs =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
-  Vector4 get tqqt =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
-  Vector4 get tqqp =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
-  Vector4 get tqqq =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
-  Vector4 get psss =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
-  Vector4 get psst =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
-  Vector4 get pssp =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
-  Vector4 get pssq =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
-  Vector4 get psts =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
-  Vector4 get pstt =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
-  Vector4 get pstp =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
-  Vector4 get pstq =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
-  Vector4 get psps =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
-  Vector4 get pspt =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
-  Vector4 get pspp =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
-  Vector4 get pspq =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
-  Vector4 get psqs =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
-  Vector4 get psqt =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
-  Vector4 get psqp =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
-  Vector4 get psqq =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
-  Vector4 get ptss =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
-  Vector4 get ptst =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
-  Vector4 get ptsp =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
-  Vector4 get ptsq =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
-  Vector4 get ptts =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
-  Vector4 get pttt =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
-  Vector4 get pttp =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
-  Vector4 get pttq =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
-  Vector4 get ptps =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
-  Vector4 get ptpt =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
-  Vector4 get ptpp =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
-  Vector4 get ptpq =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
-  Vector4 get ptqs =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
-  Vector4 get ptqt =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
-  Vector4 get ptqp =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
-  Vector4 get ptqq =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
-  Vector4 get ppss =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
-  Vector4 get ppst =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
-  Vector4 get ppsp =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
-  Vector4 get ppsq =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
-  Vector4 get ppts =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
-  Vector4 get pptt =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
-  Vector4 get pptp =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
-  Vector4 get pptq =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
-  Vector4 get ppps =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
-  Vector4 get pppt =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
-  Vector4 get pppp =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
-  Vector4 get pppq =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
-  Vector4 get ppqs =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
-  Vector4 get ppqt =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
-  Vector4 get ppqp =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
-  Vector4 get ppqq =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
-  Vector4 get pqss =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
-  Vector4 get pqst =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
-  Vector4 get pqsp =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
-  Vector4 get pqsq =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
-  Vector4 get pqts =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
-  Vector4 get pqtt =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
-  Vector4 get pqtp =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
-  Vector4 get pqtq =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
-  Vector4 get pqps =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
-  Vector4 get pqpt =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
-  Vector4 get pqpp =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
-  Vector4 get pqpq =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
-  Vector4 get pqqs =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
-  Vector4 get pqqt =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
-  Vector4 get pqqp =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
-  Vector4 get pqqq =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
-  Vector4 get qsss =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
-  Vector4 get qsst =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
-  Vector4 get qssp =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
-  Vector4 get qssq =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
-  Vector4 get qsts =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
-  Vector4 get qstt =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
-  Vector4 get qstp =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
-  Vector4 get qstq =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
-  Vector4 get qsps =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
-  Vector4 get qspt =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
-  Vector4 get qspp =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
-  Vector4 get qspq =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
-  Vector4 get qsqs =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
-  Vector4 get qsqt =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
-  Vector4 get qsqp =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
-  Vector4 get qsqq =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
-  Vector4 get qtss =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
-  Vector4 get qtst =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
-  Vector4 get qtsp =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
-  Vector4 get qtsq =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
-  Vector4 get qtts =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
-  Vector4 get qttt =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
-  Vector4 get qttp =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
-  Vector4 get qttq =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
-  Vector4 get qtps =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
-  Vector4 get qtpt =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
-  Vector4 get qtpp =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
-  Vector4 get qtpq =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
-  Vector4 get qtqs =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
-  Vector4 get qtqt =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
-  Vector4 get qtqp =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
-  Vector4 get qtqq =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
-  Vector4 get qpss =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
-  Vector4 get qpst =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
-  Vector4 get qpsp =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
-  Vector4 get qpsq =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
-  Vector4 get qpts =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
-  Vector4 get qptt =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
-  Vector4 get qptp =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
-  Vector4 get qptq =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
-  Vector4 get qpps =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
-  Vector4 get qppt =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
-  Vector4 get qppp =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
-  Vector4 get qppq =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
-  Vector4 get qpqs =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
-  Vector4 get qpqt =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
-  Vector4 get qpqp =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
-  Vector4 get qpqq =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
-  Vector4 get qqss =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
-  Vector4 get qqst =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
-  Vector4 get qqsp =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
-  Vector4 get qqsq =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
-  Vector4 get qqts =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
-  Vector4 get qqtt =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
-  Vector4 get qqtp =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
-  Vector4 get qqtq =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
-  Vector4 get qqps =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
-  Vector4 get qqpt =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
-  Vector4 get qqpp =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
-  Vector4 get qqpq =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
-  Vector4 get qqqs =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
-  Vector4 get qqqt =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
-  Vector4 get qqqp =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
-  Vector4 get qqqq =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[3]);
+  double get r => x;
+  double get g => y;
+  double get b => z;
+  double get a => w;
+  double get s => x;
+  double get t => y;
+  double get p => z;
+  double get q => w;
+  double get x => _storage[0];
+  double get y => _storage[1];
+  double get z => _storage[2];
+  double get w => _storage[3];
+  Vector2 get rr => xx;
+  Vector2 get rg => xy;
+  Vector2 get rb => xz;
+  Vector2 get ra => xw;
+  Vector2 get gr => yx;
+  Vector2 get gg => yy;
+  Vector2 get gb => yz;
+  Vector2 get ga => yw;
+  Vector2 get br => zx;
+  Vector2 get bg => zy;
+  Vector2 get bb => zz;
+  Vector2 get ba => zw;
+  Vector2 get ar => wx;
+  Vector2 get ag => wy;
+  Vector2 get ab => wz;
+  Vector2 get aa => ww;
+  Vector3 get rrr => xxx;
+  Vector3 get rrg => xxy;
+  Vector3 get rrb => xxz;
+  Vector3 get rra => xxw;
+  Vector3 get rgr => xyx;
+  Vector3 get rgg => xyy;
+  Vector3 get rgb => xyz;
+  Vector3 get rga => xyw;
+  Vector3 get rbr => xzx;
+  Vector3 get rbg => xzy;
+  Vector3 get rbb => xzz;
+  Vector3 get rba => xzw;
+  Vector3 get rar => xwx;
+  Vector3 get rag => xwy;
+  Vector3 get rab => xwz;
+  Vector3 get raa => xww;
+  Vector3 get grr => yxx;
+  Vector3 get grg => yxy;
+  Vector3 get grb => yxz;
+  Vector3 get gra => yxw;
+  Vector3 get ggr => yyx;
+  Vector3 get ggg => yyy;
+  Vector3 get ggb => yyz;
+  Vector3 get gga => yyw;
+  Vector3 get gbr => yzx;
+  Vector3 get gbg => yzy;
+  Vector3 get gbb => yzz;
+  Vector3 get gba => yzw;
+  Vector3 get gar => ywx;
+  Vector3 get gag => ywy;
+  Vector3 get gab => ywz;
+  Vector3 get gaa => yww;
+  Vector3 get brr => zxx;
+  Vector3 get brg => zxy;
+  Vector3 get brb => zxz;
+  Vector3 get bra => zxw;
+  Vector3 get bgr => zyx;
+  Vector3 get bgg => zyy;
+  Vector3 get bgb => zyz;
+  Vector3 get bga => zyw;
+  Vector3 get bbr => zzx;
+  Vector3 get bbg => zzy;
+  Vector3 get bbb => zzz;
+  Vector3 get bba => zzw;
+  Vector3 get bar => zwx;
+  Vector3 get bag => zwy;
+  Vector3 get bab => zwz;
+  Vector3 get baa => zww;
+  Vector3 get arr => wxx;
+  Vector3 get arg => wxy;
+  Vector3 get arb => wxz;
+  Vector3 get ara => wxw;
+  Vector3 get agr => wyx;
+  Vector3 get agg => wyy;
+  Vector3 get agb => wyz;
+  Vector3 get aga => wyw;
+  Vector3 get abr => wzx;
+  Vector3 get abg => wzy;
+  Vector3 get abb => wzz;
+  Vector3 get aba => wzw;
+  Vector3 get aar => wwx;
+  Vector3 get aag => wwy;
+  Vector3 get aab => wwz;
+  Vector3 get aaa => www;
+  Vector4 get rrrr => xxxx;
+  Vector4 get rrrg => xxxy;
+  Vector4 get rrrb => xxxz;
+  Vector4 get rrra => xxxw;
+  Vector4 get rrgr => xxyx;
+  Vector4 get rrgg => xxyy;
+  Vector4 get rrgb => xxyz;
+  Vector4 get rrga => xxyw;
+  Vector4 get rrbr => xxzx;
+  Vector4 get rrbg => xxzy;
+  Vector4 get rrbb => xxzz;
+  Vector4 get rrba => xxzw;
+  Vector4 get rrar => xxwx;
+  Vector4 get rrag => xxwy;
+  Vector4 get rrab => xxwz;
+  Vector4 get rraa => xxww;
+  Vector4 get rgrr => xyxx;
+  Vector4 get rgrg => xyxy;
+  Vector4 get rgrb => xyxz;
+  Vector4 get rgra => xyxw;
+  Vector4 get rggr => xyyx;
+  Vector4 get rggg => xyyy;
+  Vector4 get rggb => xyyz;
+  Vector4 get rgga => xyyw;
+  Vector4 get rgbr => xyzx;
+  Vector4 get rgbg => xyzy;
+  Vector4 get rgbb => xyzz;
+  Vector4 get rgba => xyzw;
+  Vector4 get rgar => xywx;
+  Vector4 get rgag => xywy;
+  Vector4 get rgab => xywz;
+  Vector4 get rgaa => xyww;
+  Vector4 get rbrr => xzxx;
+  Vector4 get rbrg => xzxy;
+  Vector4 get rbrb => xzxz;
+  Vector4 get rbra => xzxw;
+  Vector4 get rbgr => xzyx;
+  Vector4 get rbgg => xzyy;
+  Vector4 get rbgb => xzyz;
+  Vector4 get rbga => xzyw;
+  Vector4 get rbbr => xzzx;
+  Vector4 get rbbg => xzzy;
+  Vector4 get rbbb => xzzz;
+  Vector4 get rbba => xzzw;
+  Vector4 get rbar => xzwx;
+  Vector4 get rbag => xzwy;
+  Vector4 get rbab => xzwz;
+  Vector4 get rbaa => xzww;
+  Vector4 get rarr => xwxx;
+  Vector4 get rarg => xwxy;
+  Vector4 get rarb => xwxz;
+  Vector4 get rara => xwxw;
+  Vector4 get ragr => xwyx;
+  Vector4 get ragg => xwyy;
+  Vector4 get ragb => xwyz;
+  Vector4 get raga => xwyw;
+  Vector4 get rabr => xwzx;
+  Vector4 get rabg => xwzy;
+  Vector4 get rabb => xwzz;
+  Vector4 get raba => xwzw;
+  Vector4 get raar => xwwx;
+  Vector4 get raag => xwwy;
+  Vector4 get raab => xwwz;
+  Vector4 get raaa => xwww;
+  Vector4 get grrr => yxxx;
+  Vector4 get grrg => yxxy;
+  Vector4 get grrb => yxxz;
+  Vector4 get grra => yxxw;
+  Vector4 get grgr => yxyx;
+  Vector4 get grgg => yxyy;
+  Vector4 get grgb => yxyz;
+  Vector4 get grga => yxyw;
+  Vector4 get grbr => yxzx;
+  Vector4 get grbg => yxzy;
+  Vector4 get grbb => yxzz;
+  Vector4 get grba => yxzw;
+  Vector4 get grar => yxwx;
+  Vector4 get grag => yxwy;
+  Vector4 get grab => yxwz;
+  Vector4 get graa => yxww;
+  Vector4 get ggrr => yyxx;
+  Vector4 get ggrg => yyxy;
+  Vector4 get ggrb => yyxz;
+  Vector4 get ggra => yyxw;
+  Vector4 get gggr => yyyx;
+  Vector4 get gggg => yyyy;
+  Vector4 get gggb => yyyz;
+  Vector4 get ggga => yyyw;
+  Vector4 get ggbr => yyzx;
+  Vector4 get ggbg => yyzy;
+  Vector4 get ggbb => yyzz;
+  Vector4 get ggba => yyzw;
+  Vector4 get ggar => yywx;
+  Vector4 get ggag => yywy;
+  Vector4 get ggab => yywz;
+  Vector4 get ggaa => yyww;
+  Vector4 get gbrr => yzxx;
+  Vector4 get gbrg => yzxy;
+  Vector4 get gbrb => yzxz;
+  Vector4 get gbra => yzxw;
+  Vector4 get gbgr => yzyx;
+  Vector4 get gbgg => yzyy;
+  Vector4 get gbgb => yzyz;
+  Vector4 get gbga => yzyw;
+  Vector4 get gbbr => yzzx;
+  Vector4 get gbbg => yzzy;
+  Vector4 get gbbb => yzzz;
+  Vector4 get gbba => yzzw;
+  Vector4 get gbar => yzwx;
+  Vector4 get gbag => yzwy;
+  Vector4 get gbab => yzwz;
+  Vector4 get gbaa => yzww;
+  Vector4 get garr => ywxx;
+  Vector4 get garg => ywxy;
+  Vector4 get garb => ywxz;
+  Vector4 get gara => ywxw;
+  Vector4 get gagr => ywyx;
+  Vector4 get gagg => ywyy;
+  Vector4 get gagb => ywyz;
+  Vector4 get gaga => ywyw;
+  Vector4 get gabr => ywzx;
+  Vector4 get gabg => ywzy;
+  Vector4 get gabb => ywzz;
+  Vector4 get gaba => ywzw;
+  Vector4 get gaar => ywwx;
+  Vector4 get gaag => ywwy;
+  Vector4 get gaab => ywwz;
+  Vector4 get gaaa => ywww;
+  Vector4 get brrr => zxxx;
+  Vector4 get brrg => zxxy;
+  Vector4 get brrb => zxxz;
+  Vector4 get brra => zxxw;
+  Vector4 get brgr => zxyx;
+  Vector4 get brgg => zxyy;
+  Vector4 get brgb => zxyz;
+  Vector4 get brga => zxyw;
+  Vector4 get brbr => zxzx;
+  Vector4 get brbg => zxzy;
+  Vector4 get brbb => zxzz;
+  Vector4 get brba => zxzw;
+  Vector4 get brar => zxwx;
+  Vector4 get brag => zxwy;
+  Vector4 get brab => zxwz;
+  Vector4 get braa => zxww;
+  Vector4 get bgrr => zyxx;
+  Vector4 get bgrg => zyxy;
+  Vector4 get bgrb => zyxz;
+  Vector4 get bgra => zyxw;
+  Vector4 get bggr => zyyx;
+  Vector4 get bggg => zyyy;
+  Vector4 get bggb => zyyz;
+  Vector4 get bgga => zyyw;
+  Vector4 get bgbr => zyzx;
+  Vector4 get bgbg => zyzy;
+  Vector4 get bgbb => zyzz;
+  Vector4 get bgba => zyzw;
+  Vector4 get bgar => zywx;
+  Vector4 get bgag => zywy;
+  Vector4 get bgab => zywz;
+  Vector4 get bgaa => zyww;
+  Vector4 get bbrr => zzxx;
+  Vector4 get bbrg => zzxy;
+  Vector4 get bbrb => zzxz;
+  Vector4 get bbra => zzxw;
+  Vector4 get bbgr => zzyx;
+  Vector4 get bbgg => zzyy;
+  Vector4 get bbgb => zzyz;
+  Vector4 get bbga => zzyw;
+  Vector4 get bbbr => zzzx;
+  Vector4 get bbbg => zzzy;
+  Vector4 get bbbb => zzzz;
+  Vector4 get bbba => zzzw;
+  Vector4 get bbar => zzwx;
+  Vector4 get bbag => zzwy;
+  Vector4 get bbab => zzwz;
+  Vector4 get bbaa => zzww;
+  Vector4 get barr => zwxx;
+  Vector4 get barg => zwxy;
+  Vector4 get barb => zwxz;
+  Vector4 get bara => zwxw;
+  Vector4 get bagr => zwyx;
+  Vector4 get bagg => zwyy;
+  Vector4 get bagb => zwyz;
+  Vector4 get baga => zwyw;
+  Vector4 get babr => zwzx;
+  Vector4 get babg => zwzy;
+  Vector4 get babb => zwzz;
+  Vector4 get baba => zwzw;
+  Vector4 get baar => zwwx;
+  Vector4 get baag => zwwy;
+  Vector4 get baab => zwwz;
+  Vector4 get baaa => zwww;
+  Vector4 get arrr => wxxx;
+  Vector4 get arrg => wxxy;
+  Vector4 get arrb => wxxz;
+  Vector4 get arra => wxxw;
+  Vector4 get argr => wxyx;
+  Vector4 get argg => wxyy;
+  Vector4 get argb => wxyz;
+  Vector4 get arga => wxyw;
+  Vector4 get arbr => wxzx;
+  Vector4 get arbg => wxzy;
+  Vector4 get arbb => wxzz;
+  Vector4 get arba => wxzw;
+  Vector4 get arar => wxwx;
+  Vector4 get arag => wxwy;
+  Vector4 get arab => wxwz;
+  Vector4 get araa => wxww;
+  Vector4 get agrr => wyxx;
+  Vector4 get agrg => wyxy;
+  Vector4 get agrb => wyxz;
+  Vector4 get agra => wyxw;
+  Vector4 get aggr => wyyx;
+  Vector4 get aggg => wyyy;
+  Vector4 get aggb => wyyz;
+  Vector4 get agga => wyyw;
+  Vector4 get agbr => wyzx;
+  Vector4 get agbg => wyzy;
+  Vector4 get agbb => wyzz;
+  Vector4 get agba => wyzw;
+  Vector4 get agar => wywx;
+  Vector4 get agag => wywy;
+  Vector4 get agab => wywz;
+  Vector4 get agaa => wyww;
+  Vector4 get abrr => wzxx;
+  Vector4 get abrg => wzxy;
+  Vector4 get abrb => wzxz;
+  Vector4 get abra => wzxw;
+  Vector4 get abgr => wzyx;
+  Vector4 get abgg => wzyy;
+  Vector4 get abgb => wzyz;
+  Vector4 get abga => wzyw;
+  Vector4 get abbr => wzzx;
+  Vector4 get abbg => wzzy;
+  Vector4 get abbb => wzzz;
+  Vector4 get abba => wzzw;
+  Vector4 get abar => wzwx;
+  Vector4 get abag => wzwy;
+  Vector4 get abab => wzwz;
+  Vector4 get abaa => wzww;
+  Vector4 get aarr => wwxx;
+  Vector4 get aarg => wwxy;
+  Vector4 get aarb => wwxz;
+  Vector4 get aara => wwxw;
+  Vector4 get aagr => wwyx;
+  Vector4 get aagg => wwyy;
+  Vector4 get aagb => wwyz;
+  Vector4 get aaga => wwyw;
+  Vector4 get aabr => wwzx;
+  Vector4 get aabg => wwzy;
+  Vector4 get aabb => wwzz;
+  Vector4 get aaba => wwzw;
+  Vector4 get aaar => wwwx;
+  Vector4 get aaag => wwwy;
+  Vector4 get aaab => wwwz;
+  Vector4 get aaaa => wwww;
+  Vector2 get ss => xx;
+  Vector2 get st => xy;
+  Vector2 get sp => xz;
+  Vector2 get sq => xw;
+  Vector2 get ts => yx;
+  Vector2 get tt => yy;
+  Vector2 get tp => yz;
+  Vector2 get tq => yw;
+  Vector2 get ps => zx;
+  Vector2 get pt => zy;
+  Vector2 get pp => zz;
+  Vector2 get pq => zw;
+  Vector2 get qs => wx;
+  Vector2 get qt => wy;
+  Vector2 get qp => wz;
+  Vector2 get qq => ww;
+  Vector3 get sss => xxx;
+  Vector3 get sst => xxy;
+  Vector3 get ssp => xxz;
+  Vector3 get ssq => xxw;
+  Vector3 get sts => xyx;
+  Vector3 get stt => xyy;
+  Vector3 get stp => xyz;
+  Vector3 get stq => xyw;
+  Vector3 get sps => xzx;
+  Vector3 get spt => xzy;
+  Vector3 get spp => xzz;
+  Vector3 get spq => xzw;
+  Vector3 get sqs => xwx;
+  Vector3 get sqt => xwy;
+  Vector3 get sqp => xwz;
+  Vector3 get sqq => xww;
+  Vector3 get tss => yxx;
+  Vector3 get tst => yxy;
+  Vector3 get tsp => yxz;
+  Vector3 get tsq => yxw;
+  Vector3 get tts => yyx;
+  Vector3 get ttt => yyy;
+  Vector3 get ttp => yyz;
+  Vector3 get ttq => yyw;
+  Vector3 get tps => yzx;
+  Vector3 get tpt => yzy;
+  Vector3 get tpp => yzz;
+  Vector3 get tpq => yzw;
+  Vector3 get tqs => ywx;
+  Vector3 get tqt => ywy;
+  Vector3 get tqp => ywz;
+  Vector3 get tqq => yww;
+  Vector3 get pss => zxx;
+  Vector3 get pst => zxy;
+  Vector3 get psp => zxz;
+  Vector3 get psq => zxw;
+  Vector3 get pts => zyx;
+  Vector3 get ptt => zyy;
+  Vector3 get ptp => zyz;
+  Vector3 get ptq => zyw;
+  Vector3 get pps => zzx;
+  Vector3 get ppt => zzy;
+  Vector3 get ppp => zzz;
+  Vector3 get ppq => zzw;
+  Vector3 get pqs => zwx;
+  Vector3 get pqt => zwy;
+  Vector3 get pqp => zwz;
+  Vector3 get pqq => zww;
+  Vector3 get qss => wxx;
+  Vector3 get qst => wxy;
+  Vector3 get qsp => wxz;
+  Vector3 get qsq => wxw;
+  Vector3 get qts => wyx;
+  Vector3 get qtt => wyy;
+  Vector3 get qtp => wyz;
+  Vector3 get qtq => wyw;
+  Vector3 get qps => wzx;
+  Vector3 get qpt => wzy;
+  Vector3 get qpp => wzz;
+  Vector3 get qpq => wzw;
+  Vector3 get qqs => wwx;
+  Vector3 get qqt => wwy;
+  Vector3 get qqp => wwz;
+  Vector3 get qqq => www;
+  Vector4 get ssss => xxxx;
+  Vector4 get ssst => xxxy;
+  Vector4 get sssp => xxxz;
+  Vector4 get sssq => xxxw;
+  Vector4 get ssts => xxyx;
+  Vector4 get sstt => xxyy;
+  Vector4 get sstp => xxyz;
+  Vector4 get sstq => xxyw;
+  Vector4 get ssps => xxzx;
+  Vector4 get sspt => xxzy;
+  Vector4 get sspp => xxzz;
+  Vector4 get sspq => xxzw;
+  Vector4 get ssqs => xxwx;
+  Vector4 get ssqt => xxwy;
+  Vector4 get ssqp => xxwz;
+  Vector4 get ssqq => xxww;
+  Vector4 get stss => xyxx;
+  Vector4 get stst => xyxy;
+  Vector4 get stsp => xyxz;
+  Vector4 get stsq => xyxw;
+  Vector4 get stts => xyyx;
+  Vector4 get sttt => xyyy;
+  Vector4 get sttp => xyyz;
+  Vector4 get sttq => xyyw;
+  Vector4 get stps => xyzx;
+  Vector4 get stpt => xyzy;
+  Vector4 get stpp => xyzz;
+  Vector4 get stpq => xyzw;
+  Vector4 get stqs => xywx;
+  Vector4 get stqt => xywy;
+  Vector4 get stqp => xywz;
+  Vector4 get stqq => xyww;
+  Vector4 get spss => xzxx;
+  Vector4 get spst => xzxy;
+  Vector4 get spsp => xzxz;
+  Vector4 get spsq => xzxw;
+  Vector4 get spts => xzyx;
+  Vector4 get sptt => xzyy;
+  Vector4 get sptp => xzyz;
+  Vector4 get sptq => xzyw;
+  Vector4 get spps => xzzx;
+  Vector4 get sppt => xzzy;
+  Vector4 get sppp => xzzz;
+  Vector4 get sppq => xzzw;
+  Vector4 get spqs => xzwx;
+  Vector4 get spqt => xzwy;
+  Vector4 get spqp => xzwz;
+  Vector4 get spqq => xzww;
+  Vector4 get sqss => xwxx;
+  Vector4 get sqst => xwxy;
+  Vector4 get sqsp => xwxz;
+  Vector4 get sqsq => xwxw;
+  Vector4 get sqts => xwyx;
+  Vector4 get sqtt => xwyy;
+  Vector4 get sqtp => xwyz;
+  Vector4 get sqtq => xwyw;
+  Vector4 get sqps => xwzx;
+  Vector4 get sqpt => xwzy;
+  Vector4 get sqpp => xwzz;
+  Vector4 get sqpq => xwzw;
+  Vector4 get sqqs => xwwx;
+  Vector4 get sqqt => xwwy;
+  Vector4 get sqqp => xwwz;
+  Vector4 get sqqq => xwww;
+  Vector4 get tsss => yxxx;
+  Vector4 get tsst => yxxy;
+  Vector4 get tssp => yxxz;
+  Vector4 get tssq => yxxw;
+  Vector4 get tsts => yxyx;
+  Vector4 get tstt => yxyy;
+  Vector4 get tstp => yxyz;
+  Vector4 get tstq => yxyw;
+  Vector4 get tsps => yxzx;
+  Vector4 get tspt => yxzy;
+  Vector4 get tspp => yxzz;
+  Vector4 get tspq => yxzw;
+  Vector4 get tsqs => yxwx;
+  Vector4 get tsqt => yxwy;
+  Vector4 get tsqp => yxwz;
+  Vector4 get tsqq => yxww;
+  Vector4 get ttss => yyxx;
+  Vector4 get ttst => yyxy;
+  Vector4 get ttsp => yyxz;
+  Vector4 get ttsq => yyxw;
+  Vector4 get ttts => yyyx;
+  Vector4 get tttt => yyyy;
+  Vector4 get tttp => yyyz;
+  Vector4 get tttq => yyyw;
+  Vector4 get ttps => yyzx;
+  Vector4 get ttpt => yyzy;
+  Vector4 get ttpp => yyzz;
+  Vector4 get ttpq => yyzw;
+  Vector4 get ttqs => yywx;
+  Vector4 get ttqt => yywy;
+  Vector4 get ttqp => yywz;
+  Vector4 get ttqq => yyww;
+  Vector4 get tpss => yzxx;
+  Vector4 get tpst => yzxy;
+  Vector4 get tpsp => yzxz;
+  Vector4 get tpsq => yzxw;
+  Vector4 get tpts => yzyx;
+  Vector4 get tptt => yzyy;
+  Vector4 get tptp => yzyz;
+  Vector4 get tptq => yzyw;
+  Vector4 get tpps => yzzx;
+  Vector4 get tppt => yzzy;
+  Vector4 get tppp => yzzz;
+  Vector4 get tppq => yzzw;
+  Vector4 get tpqs => yzwx;
+  Vector4 get tpqt => yzwy;
+  Vector4 get tpqp => yzwz;
+  Vector4 get tpqq => yzww;
+  Vector4 get tqss => ywxx;
+  Vector4 get tqst => ywxy;
+  Vector4 get tqsp => ywxz;
+  Vector4 get tqsq => ywxw;
+  Vector4 get tqts => ywyx;
+  Vector4 get tqtt => ywyy;
+  Vector4 get tqtp => ywyz;
+  Vector4 get tqtq => ywyw;
+  Vector4 get tqps => ywzx;
+  Vector4 get tqpt => ywzy;
+  Vector4 get tqpp => ywzz;
+  Vector4 get tqpq => ywzw;
+  Vector4 get tqqs => ywwx;
+  Vector4 get tqqt => ywwy;
+  Vector4 get tqqp => ywwz;
+  Vector4 get tqqq => ywww;
+  Vector4 get psss => zxxx;
+  Vector4 get psst => zxxy;
+  Vector4 get pssp => zxxz;
+  Vector4 get pssq => zxxw;
+  Vector4 get psts => zxyx;
+  Vector4 get pstt => zxyy;
+  Vector4 get pstp => zxyz;
+  Vector4 get pstq => zxyw;
+  Vector4 get psps => zxzx;
+  Vector4 get pspt => zxzy;
+  Vector4 get pspp => zxzz;
+  Vector4 get pspq => zxzw;
+  Vector4 get psqs => zxwx;
+  Vector4 get psqt => zxwy;
+  Vector4 get psqp => zxwz;
+  Vector4 get psqq => zxww;
+  Vector4 get ptss => zyxx;
+  Vector4 get ptst => zyxy;
+  Vector4 get ptsp => zyxz;
+  Vector4 get ptsq => zyxw;
+  Vector4 get ptts => zyyx;
+  Vector4 get pttt => zyyy;
+  Vector4 get pttp => zyyz;
+  Vector4 get pttq => zyyw;
+  Vector4 get ptps => zyzx;
+  Vector4 get ptpt => zyzy;
+  Vector4 get ptpp => zyzz;
+  Vector4 get ptpq => zyzw;
+  Vector4 get ptqs => zywx;
+  Vector4 get ptqt => zywy;
+  Vector4 get ptqp => zywz;
+  Vector4 get ptqq => zyww;
+  Vector4 get ppss => zzxx;
+  Vector4 get ppst => zzxy;
+  Vector4 get ppsp => zzxz;
+  Vector4 get ppsq => zzxw;
+  Vector4 get ppts => zzyx;
+  Vector4 get pptt => zzyy;
+  Vector4 get pptp => zzyz;
+  Vector4 get pptq => zzyw;
+  Vector4 get ppps => zzzx;
+  Vector4 get pppt => zzzy;
+  Vector4 get pppp => zzzz;
+  Vector4 get pppq => zzzw;
+  Vector4 get ppqs => zzwx;
+  Vector4 get ppqt => zzwy;
+  Vector4 get ppqp => zzwz;
+  Vector4 get ppqq => zzww;
+  Vector4 get pqss => zwxx;
+  Vector4 get pqst => zwxy;
+  Vector4 get pqsp => zwxz;
+  Vector4 get pqsq => zwxw;
+  Vector4 get pqts => zwyx;
+  Vector4 get pqtt => zwyy;
+  Vector4 get pqtp => zwyz;
+  Vector4 get pqtq => zwyw;
+  Vector4 get pqps => zwzx;
+  Vector4 get pqpt => zwzy;
+  Vector4 get pqpp => zwzz;
+  Vector4 get pqpq => zwzw;
+  Vector4 get pqqs => zwwx;
+  Vector4 get pqqt => zwwy;
+  Vector4 get pqqp => zwwz;
+  Vector4 get pqqq => zwww;
+  Vector4 get qsss => wxxx;
+  Vector4 get qsst => wxxy;
+  Vector4 get qssp => wxxz;
+  Vector4 get qssq => wxxw;
+  Vector4 get qsts => wxyx;
+  Vector4 get qstt => wxyy;
+  Vector4 get qstp => wxyz;
+  Vector4 get qstq => wxyw;
+  Vector4 get qsps => wxzx;
+  Vector4 get qspt => wxzy;
+  Vector4 get qspp => wxzz;
+  Vector4 get qspq => wxzw;
+  Vector4 get qsqs => wxwx;
+  Vector4 get qsqt => wxwy;
+  Vector4 get qsqp => wxwz;
+  Vector4 get qsqq => wxww;
+  Vector4 get qtss => wyxx;
+  Vector4 get qtst => wyxy;
+  Vector4 get qtsp => wyxz;
+  Vector4 get qtsq => wyxw;
+  Vector4 get qtts => wyyx;
+  Vector4 get qttt => wyyy;
+  Vector4 get qttp => wyyz;
+  Vector4 get qttq => wyyw;
+  Vector4 get qtps => wyzx;
+  Vector4 get qtpt => wyzy;
+  Vector4 get qtpp => wyzz;
+  Vector4 get qtpq => wyzw;
+  Vector4 get qtqs => wywx;
+  Vector4 get qtqt => wywy;
+  Vector4 get qtqp => wywz;
+  Vector4 get qtqq => wyww;
+  Vector4 get qpss => wzxx;
+  Vector4 get qpst => wzxy;
+  Vector4 get qpsp => wzxz;
+  Vector4 get qpsq => wzxw;
+  Vector4 get qpts => wzyx;
+  Vector4 get qptt => wzyy;
+  Vector4 get qptp => wzyz;
+  Vector4 get qptq => wzyw;
+  Vector4 get qpps => wzzx;
+  Vector4 get qppt => wzzy;
+  Vector4 get qppp => wzzz;
+  Vector4 get qppq => wzzw;
+  Vector4 get qpqs => wzwx;
+  Vector4 get qpqt => wzwy;
+  Vector4 get qpqp => wzwz;
+  Vector4 get qpqq => wzww;
+  Vector4 get qqss => wwxx;
+  Vector4 get qqst => wwxy;
+  Vector4 get qqsp => wwxz;
+  Vector4 get qqsq => wwxw;
+  Vector4 get qqts => wwyx;
+  Vector4 get qqtt => wwyy;
+  Vector4 get qqtp => wwyz;
+  Vector4 get qqtq => wwyw;
+  Vector4 get qqps => wwzx;
+  Vector4 get qqpt => wwzy;
+  Vector4 get qqpp => wwzz;
+  Vector4 get qqpq => wwzw;
+  Vector4 get qqqs => wwwx;
+  Vector4 get qqqt => wwwy;
+  Vector4 get qqqp => wwwz;
+  Vector4 get qqqq => wwww;
 }

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -6,7 +6,7 @@ part of vector_math_64;
 
 /// 4D column vector.
 class Vector4 implements Vector {
-  final Float64List storage = new Float64List(4);
+  final Float64List _storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector4 a, Vector4 b, Vector4 result) {
@@ -24,8 +24,8 @@ class Vector4 implements Vector {
     result.w = Math.max(a.w, b.w);
   }
 
-  // Interpolate between [min] and [max] with the amount of [a] using a linear
-  // interpolation and set the values to [result].
+  /// Interpolate between [min] and [max] with the amount of [a] using a linear
+  /// interpolation and store the values in [result].
   static void mix(Vector4 min, Vector4 max, double a, Vector4 result) {
     result.x = min.x + a * (max.x - min.x);
     result.y = min.y + a * (max.y - min.y);
@@ -33,127 +33,120 @@ class Vector4 implements Vector {
     result.w = min.w + a * (max.w - min.w);
   }
 
-  /// Constructs a new vector with the specified values.
-  Vector4(double x_, double y_, double z_, double w_) {
-    setValues(x_, y_, z_, w_);
-  }
+  /// The components of the vector.
+  Float64List get storage => _storage;
+
+  /// Construct a new vector with the specified values.
+  factory Vector4(double x, double y, double z, double w) =>
+      new Vector4.zero()..setValues(x, y, z, w);
 
   /// Initialized with values from [array] starting at [offset].
-  Vector4.array(List<double> array, [int offset = 0]) {
-    int i = offset;
-    storage[0] = array[i + 0];
-    storage[1] = array[i + 1];
-    storage[2] = array[i + 2];
-    storage[3] = array[i + 3];
-  }
+  factory Vector4.array(List<double> array, [int offset = 0]) =>
+      new Vector4.zero()..copyFromArray(array, offset);
 
-  //// Zero vector.
-  Vector4.zero();
+  /// Zero vector.
+  Vector4.zero() : _storage = new Float64List(4);
 
   /// Constructs the identity vector.
-  Vector4.identity() {
-    storage[3] = 1.0;
-  }
+  factory Vector4.identity() => new Vector4.zero()..setIdentity();
 
   /// Splat [value] into all lanes of the vector.
-  Vector4.all(double value) : this(value, value, value, value);
+  factory Vector4.all(double value) => new Vector4.zero()..splat(value);
 
   /// Copy of [other].
-  Vector4.copy(Vector4 other) {
-    setFrom(other);
-  }
+  factory Vector4.copy(Vector4 other) => new Vector4.zero()..setFrom(other);
+
+  /// Constructs Vector4 with given Float64List as [storage].
+  Vector4.fromFloat64List(this._storage);
+
+  /// Constructs Vector4 with a [storage] that views given [buffer] starting at
+  /// [offset]. [offset] has to be multiple of [Float64List.BYTES_PER_ELEMENT].
+  Vector4.fromBuffer(ByteBuffer buffer, int offset)
+      : _storage = new Float64List.view(buffer, offset, 4);
 
   /// Set the values of the vector.
   Vector4 setValues(double x_, double y_, double z_, double w_) {
-    storage[3] = w_;
-    storage[2] = z_;
-    storage[1] = y_;
-    storage[0] = x_;
+    _storage[3] = w_;
+    _storage[2] = z_;
+    _storage[1] = y_;
+    _storage[0] = x_;
     return this;
   }
 
   /// Zero the vector.
   Vector4 setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
-    storage[2] = 0.0;
-    storage[3] = 0.0;
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
+    _storage[2] = 0.0;
+    _storage[3] = 0.0;
+    return this;
+  }
+
+  /// Set to the identity vector.
+  Vector4 setIdentity() {
+    _storage[0] = 0.0;
+    _storage[1] = 0.0;
+    _storage[2] = 0.0;
+    _storage[3] = 1.0;
     return this;
   }
 
   /// Set the values by copying them from [other].
   Vector4 setFrom(Vector4 other) {
-    storage[3] = other.storage[3];
-    storage[2] = other.storage[2];
-    storage[1] = other.storage[1];
-    storage[0] = other.storage[0];
+    final otherStorage = other._storage;
+    _storage[3] = otherStorage[3];
+    _storage[2] = otherStorage[2];
+    _storage[1] = otherStorage[1];
+    _storage[0] = otherStorage[0];
     return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
   Vector4 splat(double arg) {
-    storage[3] = arg;
-    storage[2] = arg;
-    storage[1] = arg;
-    storage[0] = arg;
+    _storage[3] = arg;
+    _storage[2] = arg;
+    _storage[1] = arg;
+    _storage[0] = arg;
     return this;
   }
 
   /// Returns a printable string
-  String toString() => '${storage[0]},${storage[1]},'
-      '${storage[2]},${storage[3]}';
+  String toString() => '${_storage[0]},${_storage[1]},'
+      '${_storage[2]},${_storage[3]}';
 
   /// Negate.
-  Vector4 operator -() =>
-      new Vector4(-storage[0], -storage[1], -storage[2], -storage[3]);
+  Vector4 operator -() => clone()..negate();
 
   /// Subtract two vectors.
-  Vector4 operator -(Vector4 other) => new Vector4(
-      storage[0] - other.storage[0], storage[1] - other.storage[1],
-      storage[2] - other.storage[2], storage[3] - other.storage[3]);
+  Vector4 operator -(Vector4 other) => clone()..sub(other);
 
   /// Add two vectors.
-  Vector4 operator +(Vector4 other) => new Vector4(
-      storage[0] + other.storage[0], storage[1] + other.storage[1],
-      storage[2] + other.storage[2], storage[3] + other.storage[3]);
+  Vector4 operator +(Vector4 other) => clone()..add(other);
 
   /// Scale.
-  Vector4 operator /(double scale) {
-    var o = 1.0 / scale;
-    return new Vector4(
-        storage[0] * o, storage[1] * o, storage[2] * o, storage[3] * o);
-  }
+  Vector4 operator /(double scale) => clone()..scale(1.0 / scale);
 
   /// Scale.
-  Vector4 operator *(double scale) {
-    var o = scale;
-    return new Vector4(
-        storage[0] * o, storage[1] * o, storage[2] * o, storage[3] * o);
-  }
+  Vector4 operator *(double scale) => clone()..scale(scale);
 
-  double operator [](int i) => storage[i];
+  /// Access the component of the vector at the index [i].
+  double operator [](int i) => _storage[i];
 
+  /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    storage[i] = v;
+    _storage[i] = v;
   }
 
   /// Length.
-  double get length {
-    double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    sum += (storage[2] * storage[2]);
-    sum += (storage[3] * storage[3]);
-    return Math.sqrt(sum);
-  }
+  double get length => Math.sqrt(length2);
 
   /// Length squared.
   double get length2 {
     double sum;
-    sum = (storage[0] * storage[0]);
-    sum += (storage[1] * storage[1]);
-    sum += (storage[2] * storage[2]);
-    sum += (storage[3] * storage[3]);
+    sum = (_storage[0] * _storage[0]);
+    sum += (_storage[1] * _storage[1]);
+    sum += (_storage[2] * _storage[2]);
+    sum += (_storage[3] * _storage[3]);
     return sum;
   }
 
@@ -165,10 +158,10 @@ class Vector4 implements Vector {
       return this;
     }
     l = 1.0 / l;
-    storage[0] *= l;
-    storage[1] *= l;
-    storage[2] *= l;
-    storage[3] *= l;
+    _storage[0] *= l;
+    _storage[1] *= l;
+    _storage[2] *= l;
+    _storage[3] *= l;
     return this;
   }
 
@@ -179,17 +172,15 @@ class Vector4 implements Vector {
       return 0.0;
     }
     var d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
-    storage[2] *= d;
-    storage[3] *= d;
+    _storage[0] *= d;
+    _storage[1] *= d;
+    _storage[2] *= d;
+    _storage[3] *= d;
     return l;
   }
 
   /// Normalizes copy of [this].
-  Vector4 normalized() {
-    return new Vector4.copy(this).normalize();
-  }
+  Vector4 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector4 normalizeInto(Vector4 out) {
@@ -202,21 +193,23 @@ class Vector4 implements Vector {
 
   /// Squared distance from [this] to [arg]
   double distanceToSquared(Vector4 arg) {
-    final dx = x - arg.x;
-    final dy = y - arg.y;
-    final dz = z - arg.z;
-    final dw = w - arg.w;
+    final argStorage = arg._storage;
+    final dx = _storage[0] - argStorage[0];
+    final dy = _storage[1] - argStorage[1];
+    final dz = _storage[2] - argStorage[2];
+    final dw = _storage[3] - argStorage[3];
 
     return dx * dx + dy * dy + dz * dz + dw * dw;
   }
 
   /// Inner product.
   double dot(Vector4 other) {
+    final otherStorage = other._storage;
     double sum;
-    sum = storage[0] * other.storage[0];
-    sum += storage[1] * other.storage[1];
-    sum += storage[2] * other.storage[2];
-    sum += storage[3] * other.storage[3];
+    sum = _storage[0] * otherStorage[0];
+    sum += _storage[1] * otherStorage[1];
+    sum += _storage[2] * otherStorage[2];
+    sum += _storage[3] * otherStorage[3];
     return sum;
   }
 
@@ -235,93 +228,103 @@ class Vector4 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     bool is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
-    is_infinite = is_infinite || storage[2].isInfinite;
-    is_infinite = is_infinite || storage[3].isInfinite;
+    is_infinite = is_infinite || _storage[0].isInfinite;
+    is_infinite = is_infinite || _storage[1].isInfinite;
+    is_infinite = is_infinite || _storage[2].isInfinite;
+    is_infinite = is_infinite || _storage[3].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     bool is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
-    is_nan = is_nan || storage[2].isNaN;
-    is_nan = is_nan || storage[3].isNaN;
+    is_nan = is_nan || _storage[0].isNaN;
+    is_nan = is_nan || _storage[1].isNaN;
+    is_nan = is_nan || _storage[2].isNaN;
+    is_nan = is_nan || _storage[3].isNaN;
     return is_nan;
   }
 
   Vector4 add(Vector4 arg) {
-    storage[0] = storage[0] + arg.storage[0];
-    storage[1] = storage[1] + arg.storage[1];
-    storage[2] = storage[2] + arg.storage[2];
-    storage[3] = storage[3] + arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0];
+    _storage[1] = _storage[1] + argStorage[1];
+    _storage[2] = _storage[2] + argStorage[2];
+    _storage[3] = _storage[3] + argStorage[3];
     return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
   Vector4 addScaled(Vector4 arg, double factor) {
-    storage[0] = storage[0] + arg.storage[0] * factor;
-    storage[1] = storage[1] + arg.storage[1] * factor;
-    storage[2] = storage[2] + arg.storage[2] * factor;
-    storage[3] = storage[3] + arg.storage[3] * factor;
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] + argStorage[0] * factor;
+    _storage[1] = _storage[1] + argStorage[1] * factor;
+    _storage[2] = _storage[2] + argStorage[2] * factor;
+    _storage[3] = _storage[3] + argStorage[3] * factor;
     return this;
   }
 
+  /// Subtract [arg] from [this].
   Vector4 sub(Vector4 arg) {
-    storage[0] = storage[0] - arg.storage[0];
-    storage[1] = storage[1] - arg.storage[1];
-    storage[2] = storage[2] - arg.storage[2];
-    storage[3] = storage[3] - arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] - argStorage[0];
+    _storage[1] = _storage[1] - argStorage[1];
+    _storage[2] = _storage[2] - argStorage[2];
+    _storage[3] = _storage[3] - argStorage[3];
     return this;
   }
 
+  /// Multiply [this] by [arg].
   Vector4 multiply(Vector4 arg) {
-    storage[0] = storage[0] * arg.storage[0];
-    storage[1] = storage[1] * arg.storage[1];
-    storage[2] = storage[2] * arg.storage[2];
-    storage[3] = storage[3] * arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] * argStorage[0];
+    _storage[1] = _storage[1] * argStorage[1];
+    _storage[2] = _storage[2] * argStorage[2];
+    _storage[3] = _storage[3] * argStorage[3];
     return this;
   }
 
+  /// Divide [this] by [arg].
   Vector4 div(Vector4 arg) {
-    storage[0] = storage[0] / arg.storage[0];
-    storage[1] = storage[1] / arg.storage[1];
-    storage[2] = storage[2] / arg.storage[2];
-    storage[3] = storage[3] / arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = _storage[0] / argStorage[0];
+    _storage[1] = _storage[1] / argStorage[1];
+    _storage[2] = _storage[2] / argStorage[2];
+    _storage[3] = _storage[3] / argStorage[3];
     return this;
   }
 
+  /// Scale [this] by [arg].
   Vector4 scale(double arg) {
-    storage[0] = storage[0] * arg;
-    storage[1] = storage[1] * arg;
-    storage[2] = storage[2] * arg;
-    storage[3] = storage[3] * arg;
+    _storage[0] = _storage[0] * arg;
+    _storage[1] = _storage[1] * arg;
+    _storage[2] = _storage[2] * arg;
+    _storage[3] = _storage[3] * arg;
     return this;
   }
 
-  Vector4 scaled(double arg) {
-    return clone().scale(arg);
-  }
+  /// Create a copy of [this] scaled by [arg].
+  Vector4 scaled(double arg) => clone()..scale(arg);
 
+  /// Negate [this].
   Vector4 negate() {
-    storage[0] = -storage[0];
-    storage[1] = -storage[1];
-    storage[2] = -storage[2];
-    storage[3] = -storage[3];
+    _storage[0] = -_storage[0];
+    _storage[1] = -_storage[1];
+    _storage[2] = -_storage[2];
+    _storage[3] = -_storage[3];
     return this;
   }
 
+  /// Set [this] to the absolute.
   Vector4 absolute() {
-    storage[3] = storage[3].abs();
-    storage[2] = storage[2].abs();
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    _storage[3] = _storage[3].abs();
+    _storage[2] = _storage[2].abs();
+    _storage[1] = _storage[1].abs();
+    _storage[0] = _storage[0].abs();
     return this;
   }
-  
-  /// Clamp each entry n in [this] in the range [min[n]]-[max[n]]. 
+
+  /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
   Vector4 clamp(Vector4 min, Vector4 max) {
     storage[0] = storage[0].clamp(min.storage[0], max.storage[0]);
     storage[1] = storage[1].clamp(min.storage[1], max.storage[1]);
@@ -329,7 +332,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].clamp(min.storage[3], max.storage[3]);
     return this;
   }
-  
+
   /// Clamp entries in [this] in the range [min]-[max].
   Vector4 clampScalar(double min, double max) {
     storage[0] = storage[0].clamp(min, max);
@@ -338,7 +341,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].clamp(min, max);
     return this;
   }
-  
+
   /// Floor entries in [this].
   Vector4 floor() {
     storage[0] = storage[0].floorToDouble();
@@ -347,7 +350,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].floorToDouble();
     return this;
   }
-  
+
   /// Ceil entries in [this].
   Vector4 ceil() {
     storage[0] = storage[0].ceilToDouble();
@@ -356,7 +359,7 @@ class Vector4 implements Vector {
     storage[3] = storage[3].ceilToDouble();
     return this;
   }
-  
+
   /// Round entries in [this].
   Vector4 round() {
     storage[0] = storage[0].roundToDouble();
@@ -365,2778 +368,1831 @@ class Vector4 implements Vector {
     storage[3] = storage[3].roundToDouble();
     return this;
   }
-  
+
   /// Round entries in [this] towards zero.
   Vector4 roundToZero() {
-    storage[0] = storage[0] < 0.0 ? storage[0].ceilToDouble() : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0 ? storage[1].ceilToDouble() : storage[1].floorToDouble();
-    storage[2] = storage[2] < 0.0 ? storage[2].ceilToDouble() : storage[2].floorToDouble();
-    storage[3] = storage[3] < 0.0 ? storage[3].ceilToDouble() : storage[3].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
+    storage[2] = storage[2] < 0.0
+        ? storage[2].ceilToDouble()
+        : storage[2].floorToDouble();
+    storage[3] = storage[3] < 0.0
+        ? storage[3].ceilToDouble()
+        : storage[3].floorToDouble();
     return this;
   }
 
-  Vector4 clone() {
-    return new Vector4.copy(this);
-  }
+  /// Create a copy of [this].
+  Vector4 clone() => new Vector4.copy(this);
 
+  /// Copy [this]
   Vector4 copyInto(Vector4 arg) {
-    arg.storage[0] = storage[0];
-    arg.storage[1] = storage[1];
-    arg.storage[2] = storage[2];
-    arg.storage[3] = storage[3];
+    final argStorage = arg._storage;
+    argStorage[0] = _storage[0];
+    argStorage[1] = _storage[1];
+    argStorage[2] = _storage[2];
+    argStorage[3] = _storage[3];
     return arg;
   }
 
   /// Copies [this] into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 0] = storage[0];
-    array[offset + 1] = storage[1];
-    array[offset + 2] = storage[2];
-    array[offset + 3] = storage[3];
+    array[offset + 0] = _storage[0];
+    array[offset + 1] = _storage[1];
+    array[offset + 2] = _storage[2];
+    array[offset + 3] = _storage[3];
   }
 
   /// Copies elements from [array] into [this] starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[0] = array[offset + 0];
-    storage[1] = array[offset + 1];
-    storage[2] = array[offset + 2];
-    storage[3] = array[offset + 3];
+    _storage[0] = array[offset + 0];
+    _storage[1] = array[offset + 1];
+    _storage[2] = array[offset + 2];
+    _storage[3] = array[offset + 3];
   }
 
   set xy(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set xz(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set xw(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set yx(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set yz(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set yw(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set zx(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set zy(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set zw(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
   }
   set wx(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
   }
   set wy(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
   }
   set wz(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
   }
   set xyz(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set xyw(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set xzy(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xzw(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set xwy(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xwz(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set yxz(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set yxw(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set yzx(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set yzw(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set ywx(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set ywz(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set zxy(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set zxw(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set zyx(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set zyw(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
   }
   set zwx(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set zwy(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set wxy(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set wxz(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set wyx(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set wyz(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
   }
   set wzx(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
   }
   set wzy(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
   }
   set xyzw(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set xywz(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set xzyw(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set xzwy(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set xwyz(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set xwzy(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[0] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set yxzw(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set yxwz(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set yzxw(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set yzwx(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set ywxz(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set ywzx(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[1] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set zxyw(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set zxwy(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set zyxw(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[3] = argStorage[3];
   }
   set zywx(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[3] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set zwxy(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set zwyx(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[2] = argStorage[0];
+    _storage[3] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set wxyz(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set wxzy(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[0] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set wyxz(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[2] = argStorage[3];
   }
   set wyzx(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[1] = argStorage[1];
+    _storage[2] = argStorage[2];
+    _storage[0] = argStorage[3];
   }
   set wzxy(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[0] = argStorage[2];
+    _storage[1] = argStorage[3];
   }
   set wzyx(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set r(double arg) => storage[0] = arg;
-  set g(double arg) => storage[1] = arg;
-  set b(double arg) => storage[2] = arg;
-  set a(double arg) => storage[3] = arg;
-  set s(double arg) => storage[0] = arg;
-  set t(double arg) => storage[1] = arg;
-  set p(double arg) => storage[2] = arg;
-  set q(double arg) => storage[3] = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
-  set z(double arg) => storage[2] = arg;
-  set w(double arg) => storage[3] = arg;
-  set rg(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set rb(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set ra(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set gr(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set gb(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set ga(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set br(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set bg(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ba(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ar(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set ag(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set ab(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set rgb(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set rga(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set rbg(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rba(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set rag(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rab(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set grb(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set gra(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set gbr(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set gba(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set gar(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set gab(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set brg(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set bra(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set bgr(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set bga(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set bar(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set bag(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set arg(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set arb(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set agr(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set agb(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set abr(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set abg(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set rgba(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set rgab(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set rbga(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set rbag(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set ragb(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set rabg(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set grba(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set grab(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set gbra(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set gbar(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set garb(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set gabr(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set brga(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set brag(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set bgra(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set bgar(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set barg(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set bagr(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set argb(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set arbg(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set agrb(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set agbr(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set abrg(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set abgr(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set st(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set sp(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set sq(Vector2 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ts(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set tp(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set tq(Vector2 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set ps(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set pt(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set pq(Vector2 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-  }
-  set qs(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-  }
-  set qt(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-  }
-  set qp(Vector2 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-  }
-  set stp(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set stq(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set spt(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set spq(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set sqt(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set sqp(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set tsp(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set tsq(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set tps(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set tpq(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set tqs(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set tqp(Vector3 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set pst(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set psq(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set pts(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set ptq(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-  }
-  set pqs(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set pqt(Vector3 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set qst(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set qsp(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set qts(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set qtp(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-  }
-  set qps(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-  }
-  set qpt(Vector3 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-  }
-  set stpq(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set stqp(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set sptq(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set spqt(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set sqtp(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set sqpt(Vector4 arg) {
-    storage[0] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set tspq(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set tsqp(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set tpsq(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set tpqs(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set tqsp(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set tqps(Vector4 arg) {
-    storage[1] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set pstq(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set psqt(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set ptsq(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[3] = arg.storage[3];
-  }
-  set ptqs(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[3] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set pqst(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set pqts(Vector4 arg) {
-    storage[2] = arg.storage[0];
-    storage[3] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set qstp(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set qspt(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[0] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set qtsp(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[2] = arg.storage[3];
-  }
-  set qtps(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[1] = arg.storage[1];
-    storage[2] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  set qpst(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[0] = arg.storage[2];
-    storage[1] = arg.storage[3];
-  }
-  set qpts(Vector4 arg) {
-    storage[3] = arg.storage[0];
-    storage[2] = arg.storage[1];
-    storage[1] = arg.storage[2];
-    storage[0] = arg.storage[3];
-  }
-  Vector2 get xx => new Vector2(storage[0], storage[0]);
-  Vector2 get xy => new Vector2(storage[0], storage[1]);
-  Vector2 get xz => new Vector2(storage[0], storage[2]);
-  Vector2 get xw => new Vector2(storage[0], storage[3]);
-  Vector2 get yx => new Vector2(storage[1], storage[0]);
-  Vector2 get yy => new Vector2(storage[1], storage[1]);
-  Vector2 get yz => new Vector2(storage[1], storage[2]);
-  Vector2 get yw => new Vector2(storage[1], storage[3]);
-  Vector2 get zx => new Vector2(storage[2], storage[0]);
-  Vector2 get zy => new Vector2(storage[2], storage[1]);
-  Vector2 get zz => new Vector2(storage[2], storage[2]);
-  Vector2 get zw => new Vector2(storage[2], storage[3]);
-  Vector2 get wx => new Vector2(storage[3], storage[0]);
-  Vector2 get wy => new Vector2(storage[3], storage[1]);
-  Vector2 get wz => new Vector2(storage[3], storage[2]);
-  Vector2 get ww => new Vector2(storage[3], storage[3]);
-  Vector3 get xxx => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xxz => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get xxw => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get xyx => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get xyz => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get xyw => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get xzx => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get xzy => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get xzz => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get xzw => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get xwx => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get xwy => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get xwz => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get xww => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get yxx => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yxz => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get yxw => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get yyx => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get yyz => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get yyw => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get yzx => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get yzy => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get yzz => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get yzw => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get ywx => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get ywy => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get ywz => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get yww => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get zxx => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get zxy => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get zxz => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get zxw => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get zyx => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get zyy => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get zyz => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get zyw => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get zzx => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get zzy => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get zzz => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get zzw => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get zwx => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get zwy => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get zwz => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get zww => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get wxx => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get wxy => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get wxz => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get wxw => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get wyx => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get wyy => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get wyz => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get wyw => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get wzx => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get wzy => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get wzz => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get wzw => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get wwx => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get wwy => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get wwz => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get www => new Vector3(storage[3], storage[3], storage[3]);
+    final argStorage = arg._storage;
+    _storage[3] = argStorage[0];
+    _storage[2] = argStorage[1];
+    _storage[1] = argStorage[2];
+    _storage[0] = argStorage[3];
+  }
+  set r(double arg) => x = arg;
+  set g(double arg) => y = arg;
+  set b(double arg) => z = arg;
+  set a(double arg) => w = arg;
+  set s(double arg) => x = arg;
+  set t(double arg) => y = arg;
+  set p(double arg) => z = arg;
+  set q(double arg) => w = arg;
+  set x(double arg) => _storage[0] = arg;
+  set y(double arg) => _storage[1] = arg;
+  set z(double arg) => _storage[2] = arg;
+  set w(double arg) => _storage[3] = arg;
+  set rg(Vector2 arg) => xy = arg;
+  set rb(Vector2 arg) => xz = arg;
+  set ra(Vector2 arg) => xw = arg;
+  set gr(Vector2 arg) => yx = arg;
+  set gb(Vector2 arg) => yz = arg;
+  set ga(Vector2 arg) => yw = arg;
+  set br(Vector2 arg) => zx = arg;
+  set bg(Vector2 arg) => zy = arg;
+  set ba(Vector2 arg) => zw = arg;
+  set ar(Vector2 arg) => wx = arg;
+  set ag(Vector2 arg) => wy = arg;
+  set ab(Vector2 arg) => wz = arg;
+  set rgb(Vector3 arg) => xyz = arg;
+  set rga(Vector3 arg) => xyw = arg;
+  set rbg(Vector3 arg) => xzy = arg;
+  set rba(Vector3 arg) => xzw = arg;
+  set rag(Vector3 arg) => xwy = arg;
+  set rab(Vector3 arg) => xwz = arg;
+  set grb(Vector3 arg) => yxz = arg;
+  set gra(Vector3 arg) => yxw = arg;
+  set gbr(Vector3 arg) => yzx = arg;
+  set gba(Vector3 arg) => yzw = arg;
+  set gar(Vector3 arg) => ywx = arg;
+  set gab(Vector3 arg) => ywz = arg;
+  set brg(Vector3 arg) => zxy = arg;
+  set bra(Vector3 arg) => zxw = arg;
+  set bgr(Vector3 arg) => zyx = arg;
+  set bga(Vector3 arg) => zyw = arg;
+  set bar(Vector3 arg) => zwx = arg;
+  set bag(Vector3 arg) => zwy = arg;
+  set arg(Vector3 arg) => wxy = arg;
+  set arb(Vector3 arg) => wxz = arg;
+  set agr(Vector3 arg) => wyx = arg;
+  set agb(Vector3 arg) => wyz = arg;
+  set abr(Vector3 arg) => wzx = arg;
+  set abg(Vector3 arg) => wzy = arg;
+  set rgba(Vector4 arg) => xyzw = arg;
+  set rgab(Vector4 arg) => xywz = arg;
+  set rbga(Vector4 arg) => xzyw = arg;
+  set rbag(Vector4 arg) => xzwy = arg;
+  set ragb(Vector4 arg) => xwyz = arg;
+  set rabg(Vector4 arg) => xwzy = arg;
+  set grba(Vector4 arg) => yxzw = arg;
+  set grab(Vector4 arg) => yxwz = arg;
+  set gbra(Vector4 arg) => yzxw = arg;
+  set gbar(Vector4 arg) => yzwx = arg;
+  set garb(Vector4 arg) => ywxz = arg;
+  set gabr(Vector4 arg) => ywzx = arg;
+  set brga(Vector4 arg) => zxyw = arg;
+  set brag(Vector4 arg) => zxwy = arg;
+  set bgra(Vector4 arg) => zyxw = arg;
+  set bgar(Vector4 arg) => zywx = arg;
+  set barg(Vector4 arg) => zwxy = arg;
+  set bagr(Vector4 arg) => zwyx = arg;
+  set argb(Vector4 arg) => wxyz = arg;
+  set arbg(Vector4 arg) => wxzy = arg;
+  set agrb(Vector4 arg) => wyxz = arg;
+  set agbr(Vector4 arg) => wyzx = arg;
+  set abrg(Vector4 arg) => wzxy = arg;
+  set abgr(Vector4 arg) => wzyx = arg;
+  set st(Vector2 arg) => xy = arg;
+  set sp(Vector2 arg) => xz = arg;
+  set sq(Vector2 arg) => xw = arg;
+  set ts(Vector2 arg) => yx = arg;
+  set tp(Vector2 arg) => yz = arg;
+  set tq(Vector2 arg) => yw = arg;
+  set ps(Vector2 arg) => zx = arg;
+  set pt(Vector2 arg) => zy = arg;
+  set pq(Vector2 arg) => zw = arg;
+  set qs(Vector2 arg) => wx = arg;
+  set qt(Vector2 arg) => wy = arg;
+  set qp(Vector2 arg) => wz = arg;
+  set stp(Vector3 arg) => xyz = arg;
+  set stq(Vector3 arg) => xyw = arg;
+  set spt(Vector3 arg) => xzy = arg;
+  set spq(Vector3 arg) => xzw = arg;
+  set sqt(Vector3 arg) => xwy = arg;
+  set sqp(Vector3 arg) => xwz = arg;
+  set tsp(Vector3 arg) => yxz = arg;
+  set tsq(Vector3 arg) => yxw = arg;
+  set tps(Vector3 arg) => yzx = arg;
+  set tpq(Vector3 arg) => yzw = arg;
+  set tqs(Vector3 arg) => ywx = arg;
+  set tqp(Vector3 arg) => ywz = arg;
+  set pst(Vector3 arg) => zxy = arg;
+  set psq(Vector3 arg) => zxw = arg;
+  set pts(Vector3 arg) => zyx = arg;
+  set ptq(Vector3 arg) => zyw = arg;
+  set pqs(Vector3 arg) => zwx = arg;
+  set pqt(Vector3 arg) => zwy = arg;
+  set qst(Vector3 arg) => wxy = arg;
+  set qsp(Vector3 arg) => wxz = arg;
+  set qts(Vector3 arg) => wyx = arg;
+  set qtp(Vector3 arg) => wyz = arg;
+  set qps(Vector3 arg) => wzx = arg;
+  set qpt(Vector3 arg) => wzy = arg;
+  set stpq(Vector4 arg) => xyzw = arg;
+  set stqp(Vector4 arg) => xywz = arg;
+  set sptq(Vector4 arg) => xzyw = arg;
+  set spqt(Vector4 arg) => xzwy = arg;
+  set sqtp(Vector4 arg) => xwyz = arg;
+  set sqpt(Vector4 arg) => xwzy = arg;
+  set tspq(Vector4 arg) => yxzw = arg;
+  set tsqp(Vector4 arg) => yxwz = arg;
+  set tpsq(Vector4 arg) => yzxw = arg;
+  set tpqs(Vector4 arg) => yzwx = arg;
+  set tqsp(Vector4 arg) => ywxz = arg;
+  set tqps(Vector4 arg) => ywzx = arg;
+  set pstq(Vector4 arg) => zxyw = arg;
+  set psqt(Vector4 arg) => zxwy = arg;
+  set ptsq(Vector4 arg) => zyxw = arg;
+  set ptqs(Vector4 arg) => zywx = arg;
+  set pqst(Vector4 arg) => zwxy = arg;
+  set pqts(Vector4 arg) => zwyx = arg;
+  set qstp(Vector4 arg) => wxyz = arg;
+  set qspt(Vector4 arg) => wxzy = arg;
+  set qtsp(Vector4 arg) => wyxz = arg;
+  set qtps(Vector4 arg) => wyzx = arg;
+  set qpst(Vector4 arg) => wzxy = arg;
+  set qpts(Vector4 arg) => wzyx = arg;
+  Vector2 get xx => new Vector2(_storage[0], _storage[0]);
+  Vector2 get xy => new Vector2(_storage[0], _storage[1]);
+  Vector2 get xz => new Vector2(_storage[0], _storage[2]);
+  Vector2 get xw => new Vector2(_storage[0], _storage[3]);
+  Vector2 get yx => new Vector2(_storage[1], _storage[0]);
+  Vector2 get yy => new Vector2(_storage[1], _storage[1]);
+  Vector2 get yz => new Vector2(_storage[1], _storage[2]);
+  Vector2 get yw => new Vector2(_storage[1], _storage[3]);
+  Vector2 get zx => new Vector2(_storage[2], _storage[0]);
+  Vector2 get zy => new Vector2(_storage[2], _storage[1]);
+  Vector2 get zz => new Vector2(_storage[2], _storage[2]);
+  Vector2 get zw => new Vector2(_storage[2], _storage[3]);
+  Vector2 get wx => new Vector2(_storage[3], _storage[0]);
+  Vector2 get wy => new Vector2(_storage[3], _storage[1]);
+  Vector2 get wz => new Vector2(_storage[3], _storage[2]);
+  Vector2 get ww => new Vector2(_storage[3], _storage[3]);
+  Vector3 get xxx => new Vector3(_storage[0], _storage[0], _storage[0]);
+  Vector3 get xxy => new Vector3(_storage[0], _storage[0], _storage[1]);
+  Vector3 get xxz => new Vector3(_storage[0], _storage[0], _storage[2]);
+  Vector3 get xxw => new Vector3(_storage[0], _storage[0], _storage[3]);
+  Vector3 get xyx => new Vector3(_storage[0], _storage[1], _storage[0]);
+  Vector3 get xyy => new Vector3(_storage[0], _storage[1], _storage[1]);
+  Vector3 get xyz => new Vector3(_storage[0], _storage[1], _storage[2]);
+  Vector3 get xyw => new Vector3(_storage[0], _storage[1], _storage[3]);
+  Vector3 get xzx => new Vector3(_storage[0], _storage[2], _storage[0]);
+  Vector3 get xzy => new Vector3(_storage[0], _storage[2], _storage[1]);
+  Vector3 get xzz => new Vector3(_storage[0], _storage[2], _storage[2]);
+  Vector3 get xzw => new Vector3(_storage[0], _storage[2], _storage[3]);
+  Vector3 get xwx => new Vector3(_storage[0], _storage[3], _storage[0]);
+  Vector3 get xwy => new Vector3(_storage[0], _storage[3], _storage[1]);
+  Vector3 get xwz => new Vector3(_storage[0], _storage[3], _storage[2]);
+  Vector3 get xww => new Vector3(_storage[0], _storage[3], _storage[3]);
+  Vector3 get yxx => new Vector3(_storage[1], _storage[0], _storage[0]);
+  Vector3 get yxy => new Vector3(_storage[1], _storage[0], _storage[1]);
+  Vector3 get yxz => new Vector3(_storage[1], _storage[0], _storage[2]);
+  Vector3 get yxw => new Vector3(_storage[1], _storage[0], _storage[3]);
+  Vector3 get yyx => new Vector3(_storage[1], _storage[1], _storage[0]);
+  Vector3 get yyy => new Vector3(_storage[1], _storage[1], _storage[1]);
+  Vector3 get yyz => new Vector3(_storage[1], _storage[1], _storage[2]);
+  Vector3 get yyw => new Vector3(_storage[1], _storage[1], _storage[3]);
+  Vector3 get yzx => new Vector3(_storage[1], _storage[2], _storage[0]);
+  Vector3 get yzy => new Vector3(_storage[1], _storage[2], _storage[1]);
+  Vector3 get yzz => new Vector3(_storage[1], _storage[2], _storage[2]);
+  Vector3 get yzw => new Vector3(_storage[1], _storage[2], _storage[3]);
+  Vector3 get ywx => new Vector3(_storage[1], _storage[3], _storage[0]);
+  Vector3 get ywy => new Vector3(_storage[1], _storage[3], _storage[1]);
+  Vector3 get ywz => new Vector3(_storage[1], _storage[3], _storage[2]);
+  Vector3 get yww => new Vector3(_storage[1], _storage[3], _storage[3]);
+  Vector3 get zxx => new Vector3(_storage[2], _storage[0], _storage[0]);
+  Vector3 get zxy => new Vector3(_storage[2], _storage[0], _storage[1]);
+  Vector3 get zxz => new Vector3(_storage[2], _storage[0], _storage[2]);
+  Vector3 get zxw => new Vector3(_storage[2], _storage[0], _storage[3]);
+  Vector3 get zyx => new Vector3(_storage[2], _storage[1], _storage[0]);
+  Vector3 get zyy => new Vector3(_storage[2], _storage[1], _storage[1]);
+  Vector3 get zyz => new Vector3(_storage[2], _storage[1], _storage[2]);
+  Vector3 get zyw => new Vector3(_storage[2], _storage[1], _storage[3]);
+  Vector3 get zzx => new Vector3(_storage[2], _storage[2], _storage[0]);
+  Vector3 get zzy => new Vector3(_storage[2], _storage[2], _storage[1]);
+  Vector3 get zzz => new Vector3(_storage[2], _storage[2], _storage[2]);
+  Vector3 get zzw => new Vector3(_storage[2], _storage[2], _storage[3]);
+  Vector3 get zwx => new Vector3(_storage[2], _storage[3], _storage[0]);
+  Vector3 get zwy => new Vector3(_storage[2], _storage[3], _storage[1]);
+  Vector3 get zwz => new Vector3(_storage[2], _storage[3], _storage[2]);
+  Vector3 get zww => new Vector3(_storage[2], _storage[3], _storage[3]);
+  Vector3 get wxx => new Vector3(_storage[3], _storage[0], _storage[0]);
+  Vector3 get wxy => new Vector3(_storage[3], _storage[0], _storage[1]);
+  Vector3 get wxz => new Vector3(_storage[3], _storage[0], _storage[2]);
+  Vector3 get wxw => new Vector3(_storage[3], _storage[0], _storage[3]);
+  Vector3 get wyx => new Vector3(_storage[3], _storage[1], _storage[0]);
+  Vector3 get wyy => new Vector3(_storage[3], _storage[1], _storage[1]);
+  Vector3 get wyz => new Vector3(_storage[3], _storage[1], _storage[2]);
+  Vector3 get wyw => new Vector3(_storage[3], _storage[1], _storage[3]);
+  Vector3 get wzx => new Vector3(_storage[3], _storage[2], _storage[0]);
+  Vector3 get wzy => new Vector3(_storage[3], _storage[2], _storage[1]);
+  Vector3 get wzz => new Vector3(_storage[3], _storage[2], _storage[2]);
+  Vector3 get wzw => new Vector3(_storage[3], _storage[2], _storage[3]);
+  Vector3 get wwx => new Vector3(_storage[3], _storage[3], _storage[0]);
+  Vector3 get wwy => new Vector3(_storage[3], _storage[3], _storage[1]);
+  Vector3 get wwz => new Vector3(_storage[3], _storage[3], _storage[2]);
+  Vector3 get www => new Vector3(_storage[3], _storage[3], _storage[3]);
   Vector4 get xxxx =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[0]);
   Vector4 get xxxy =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[1]);
   Vector4 get xxxz =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[2]);
   Vector4 get xxxw =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[0], _storage[3]);
   Vector4 get xxyx =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[0]);
   Vector4 get xxyy =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[1]);
   Vector4 get xxyz =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[2]);
   Vector4 get xxyw =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[1], _storage[3]);
   Vector4 get xxzx =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[0]);
   Vector4 get xxzy =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[1]);
   Vector4 get xxzz =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[2]);
   Vector4 get xxzw =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[2], _storage[3]);
   Vector4 get xxwx =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[0]);
   Vector4 get xxwy =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[1]);
   Vector4 get xxwz =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[2]);
   Vector4 get xxww =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[0], _storage[3], _storage[3]);
   Vector4 get xyxx =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[0]);
   Vector4 get xyxy =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[1]);
   Vector4 get xyxz =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[2]);
   Vector4 get xyxw =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[0], _storage[3]);
   Vector4 get xyyx =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[0]);
   Vector4 get xyyy =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[1]);
   Vector4 get xyyz =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[2]);
   Vector4 get xyyw =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[1], _storage[3]);
   Vector4 get xyzx =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[0]);
   Vector4 get xyzy =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[1]);
   Vector4 get xyzz =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[2]);
   Vector4 get xyzw =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[2], _storage[3]);
   Vector4 get xywx =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[0]);
   Vector4 get xywy =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[1]);
   Vector4 get xywz =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[2]);
   Vector4 get xyww =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[1], _storage[3], _storage[3]);
   Vector4 get xzxx =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[0]);
   Vector4 get xzxy =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[1]);
   Vector4 get xzxz =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[2]);
   Vector4 get xzxw =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[0], _storage[3]);
   Vector4 get xzyx =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[0]);
   Vector4 get xzyy =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[1]);
   Vector4 get xzyz =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[2]);
   Vector4 get xzyw =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[1], _storage[3]);
   Vector4 get xzzx =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[0]);
   Vector4 get xzzy =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[1]);
   Vector4 get xzzz =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[2]);
   Vector4 get xzzw =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[2], _storage[3]);
   Vector4 get xzwx =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[0]);
   Vector4 get xzwy =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[1]);
   Vector4 get xzwz =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[2]);
   Vector4 get xzww =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[2], _storage[3], _storage[3]);
   Vector4 get xwxx =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[0]);
   Vector4 get xwxy =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[1]);
   Vector4 get xwxz =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[2]);
   Vector4 get xwxw =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[0], _storage[3]);
   Vector4 get xwyx =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[0]);
   Vector4 get xwyy =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[1]);
   Vector4 get xwyz =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[2]);
   Vector4 get xwyw =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[1], _storage[3]);
   Vector4 get xwzx =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[0]);
   Vector4 get xwzy =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[1]);
   Vector4 get xwzz =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[2]);
   Vector4 get xwzw =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[2], _storage[3]);
   Vector4 get xwwx =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[0]);
   Vector4 get xwwy =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[1]);
   Vector4 get xwwz =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[2]);
   Vector4 get xwww =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[0], _storage[3], _storage[3], _storage[3]);
   Vector4 get yxxx =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[0]);
   Vector4 get yxxy =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[1]);
   Vector4 get yxxz =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[2]);
   Vector4 get yxxw =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[0], _storage[3]);
   Vector4 get yxyx =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[0]);
   Vector4 get yxyy =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[1]);
   Vector4 get yxyz =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[2]);
   Vector4 get yxyw =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[1], _storage[3]);
   Vector4 get yxzx =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[0]);
   Vector4 get yxzy =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[1]);
   Vector4 get yxzz =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[2]);
   Vector4 get yxzw =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[2], _storage[3]);
   Vector4 get yxwx =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[0]);
   Vector4 get yxwy =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[1]);
   Vector4 get yxwz =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[2]);
   Vector4 get yxww =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[0], _storage[3], _storage[3]);
   Vector4 get yyxx =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[0]);
   Vector4 get yyxy =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[1]);
   Vector4 get yyxz =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[2]);
   Vector4 get yyxw =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[0], _storage[3]);
   Vector4 get yyyx =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[0]);
   Vector4 get yyyy =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[1]);
   Vector4 get yyyz =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[2]);
   Vector4 get yyyw =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[1], _storage[3]);
   Vector4 get yyzx =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[0]);
   Vector4 get yyzy =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[1]);
   Vector4 get yyzz =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[2]);
   Vector4 get yyzw =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[2], _storage[3]);
   Vector4 get yywx =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[0]);
   Vector4 get yywy =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[1]);
   Vector4 get yywz =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[2]);
   Vector4 get yyww =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[1], _storage[3], _storage[3]);
   Vector4 get yzxx =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[0]);
   Vector4 get yzxy =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[1]);
   Vector4 get yzxz =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[2]);
   Vector4 get yzxw =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[0], _storage[3]);
   Vector4 get yzyx =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[0]);
   Vector4 get yzyy =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[1]);
   Vector4 get yzyz =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[2]);
   Vector4 get yzyw =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[1], _storage[3]);
   Vector4 get yzzx =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[0]);
   Vector4 get yzzy =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[1]);
   Vector4 get yzzz =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[2]);
   Vector4 get yzzw =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[2], _storage[3]);
   Vector4 get yzwx =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[0]);
   Vector4 get yzwy =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[1]);
   Vector4 get yzwz =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[2]);
   Vector4 get yzww =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[2], _storage[3], _storage[3]);
   Vector4 get ywxx =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[0]);
   Vector4 get ywxy =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[1]);
   Vector4 get ywxz =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[2]);
   Vector4 get ywxw =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[0], _storage[3]);
   Vector4 get ywyx =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[0]);
   Vector4 get ywyy =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[1]);
   Vector4 get ywyz =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[2]);
   Vector4 get ywyw =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[1], _storage[3]);
   Vector4 get ywzx =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[0]);
   Vector4 get ywzy =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[1]);
   Vector4 get ywzz =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[2]);
   Vector4 get ywzw =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[2], _storage[3]);
   Vector4 get ywwx =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[0]);
   Vector4 get ywwy =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[1]);
   Vector4 get ywwz =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[2]);
   Vector4 get ywww =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[1], _storage[3], _storage[3], _storage[3]);
   Vector4 get zxxx =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[0]);
   Vector4 get zxxy =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[1]);
   Vector4 get zxxz =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[2]);
   Vector4 get zxxw =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[0], _storage[3]);
   Vector4 get zxyx =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[0]);
   Vector4 get zxyy =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[1]);
   Vector4 get zxyz =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[2]);
   Vector4 get zxyw =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[1], _storage[3]);
   Vector4 get zxzx =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[0]);
   Vector4 get zxzy =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[1]);
   Vector4 get zxzz =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[2]);
   Vector4 get zxzw =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[2], _storage[3]);
   Vector4 get zxwx =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[0]);
   Vector4 get zxwy =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[1]);
   Vector4 get zxwz =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[2]);
   Vector4 get zxww =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[0], _storage[3], _storage[3]);
   Vector4 get zyxx =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[0]);
   Vector4 get zyxy =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[1]);
   Vector4 get zyxz =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[2]);
   Vector4 get zyxw =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[0], _storage[3]);
   Vector4 get zyyx =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[0]);
   Vector4 get zyyy =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[1]);
   Vector4 get zyyz =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[2]);
   Vector4 get zyyw =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[1], _storage[3]);
   Vector4 get zyzx =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[0]);
   Vector4 get zyzy =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[1]);
   Vector4 get zyzz =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[2]);
   Vector4 get zyzw =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[2], _storage[3]);
   Vector4 get zywx =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[0]);
   Vector4 get zywy =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[1]);
   Vector4 get zywz =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[2]);
   Vector4 get zyww =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[1], _storage[3], _storage[3]);
   Vector4 get zzxx =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[0]);
   Vector4 get zzxy =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[1]);
   Vector4 get zzxz =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[2]);
   Vector4 get zzxw =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[0], _storage[3]);
   Vector4 get zzyx =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[0]);
   Vector4 get zzyy =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[1]);
   Vector4 get zzyz =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[2]);
   Vector4 get zzyw =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[1], _storage[3]);
   Vector4 get zzzx =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[0]);
   Vector4 get zzzy =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[1]);
   Vector4 get zzzz =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[2]);
   Vector4 get zzzw =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[2], _storage[3]);
   Vector4 get zzwx =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[0]);
   Vector4 get zzwy =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[1]);
   Vector4 get zzwz =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[2]);
   Vector4 get zzww =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[2], _storage[3], _storage[3]);
   Vector4 get zwxx =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[0]);
   Vector4 get zwxy =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[1]);
   Vector4 get zwxz =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[2]);
   Vector4 get zwxw =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[0], _storage[3]);
   Vector4 get zwyx =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[0]);
   Vector4 get zwyy =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[1]);
   Vector4 get zwyz =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[2]);
   Vector4 get zwyw =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[1], _storage[3]);
   Vector4 get zwzx =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[0]);
   Vector4 get zwzy =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[1]);
   Vector4 get zwzz =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[2]);
   Vector4 get zwzw =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[2], _storage[3]);
   Vector4 get zwwx =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[0]);
   Vector4 get zwwy =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[1]);
   Vector4 get zwwz =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[2]);
   Vector4 get zwww =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[2], _storage[3], _storage[3], _storage[3]);
   Vector4 get wxxx =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[0]);
   Vector4 get wxxy =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[1]);
   Vector4 get wxxz =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[2]);
   Vector4 get wxxw =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[0], _storage[3]);
   Vector4 get wxyx =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[0]);
   Vector4 get wxyy =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[1]);
   Vector4 get wxyz =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[2]);
   Vector4 get wxyw =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[1], _storage[3]);
   Vector4 get wxzx =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[0]);
   Vector4 get wxzy =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[1]);
   Vector4 get wxzz =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[2]);
   Vector4 get wxzw =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[2], _storage[3]);
   Vector4 get wxwx =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[0]);
   Vector4 get wxwy =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[1]);
   Vector4 get wxwz =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[2]);
   Vector4 get wxww =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[0], _storage[3], _storage[3]);
   Vector4 get wyxx =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[0]);
   Vector4 get wyxy =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[1]);
   Vector4 get wyxz =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[2]);
   Vector4 get wyxw =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[0], _storage[3]);
   Vector4 get wyyx =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[0]);
   Vector4 get wyyy =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[1]);
   Vector4 get wyyz =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[2]);
   Vector4 get wyyw =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[1], _storage[3]);
   Vector4 get wyzx =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[0]);
   Vector4 get wyzy =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[1]);
   Vector4 get wyzz =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[2]);
   Vector4 get wyzw =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[2], _storage[3]);
   Vector4 get wywx =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[0]);
   Vector4 get wywy =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[1]);
   Vector4 get wywz =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[2]);
   Vector4 get wyww =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[1], _storage[3], _storage[3]);
   Vector4 get wzxx =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[0]);
   Vector4 get wzxy =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[1]);
   Vector4 get wzxz =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[2]);
   Vector4 get wzxw =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[0], _storage[3]);
   Vector4 get wzyx =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[0]);
   Vector4 get wzyy =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[1]);
   Vector4 get wzyz =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[2]);
   Vector4 get wzyw =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[1], _storage[3]);
   Vector4 get wzzx =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[0]);
   Vector4 get wzzy =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[1]);
   Vector4 get wzzz =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[2]);
   Vector4 get wzzw =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[2], _storage[3]);
   Vector4 get wzwx =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[0]);
   Vector4 get wzwy =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[1]);
   Vector4 get wzwz =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[2]);
   Vector4 get wzww =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[2], _storage[3], _storage[3]);
   Vector4 get wwxx =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[0]);
   Vector4 get wwxy =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[1]);
   Vector4 get wwxz =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[2]);
   Vector4 get wwxw =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[0], _storage[3]);
   Vector4 get wwyx =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[0]);
   Vector4 get wwyy =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[1]);
   Vector4 get wwyz =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[2]);
   Vector4 get wwyw =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[1], _storage[3]);
   Vector4 get wwzx =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[0]);
   Vector4 get wwzy =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[1]);
   Vector4 get wwzz =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[2]);
   Vector4 get wwzw =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[2], _storage[3]);
   Vector4 get wwwx =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[0]);
   Vector4 get wwwy =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[1]);
   Vector4 get wwwz =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[2]);
   Vector4 get wwww =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
-  double get r => storage[0];
-  double get g => storage[1];
-  double get b => storage[2];
-  double get a => storage[3];
-  double get s => storage[0];
-  double get t => storage[1];
-  double get p => storage[2];
-  double get q => storage[3];
-  double get x => storage[0];
-  double get y => storage[1];
-  double get z => storage[2];
-  double get w => storage[3];
-  Vector2 get rr => new Vector2(storage[0], storage[0]);
-  Vector2 get rg => new Vector2(storage[0], storage[1]);
-  Vector2 get rb => new Vector2(storage[0], storage[2]);
-  Vector2 get ra => new Vector2(storage[0], storage[3]);
-  Vector2 get gr => new Vector2(storage[1], storage[0]);
-  Vector2 get gg => new Vector2(storage[1], storage[1]);
-  Vector2 get gb => new Vector2(storage[1], storage[2]);
-  Vector2 get ga => new Vector2(storage[1], storage[3]);
-  Vector2 get br => new Vector2(storage[2], storage[0]);
-  Vector2 get bg => new Vector2(storage[2], storage[1]);
-  Vector2 get bb => new Vector2(storage[2], storage[2]);
-  Vector2 get ba => new Vector2(storage[2], storage[3]);
-  Vector2 get ar => new Vector2(storage[3], storage[0]);
-  Vector2 get ag => new Vector2(storage[3], storage[1]);
-  Vector2 get ab => new Vector2(storage[3], storage[2]);
-  Vector2 get aa => new Vector2(storage[3], storage[3]);
-  Vector3 get rrr => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get rrg => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get rrb => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get rra => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get rgr => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get rgg => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get rgb => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get rga => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get rbr => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get rbg => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get rbb => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get rba => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get rar => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get rag => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get rab => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get raa => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get grr => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get grg => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get grb => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get gra => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get ggr => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ggg => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get ggb => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get gga => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get gbr => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get gbg => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get gbb => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get gba => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get gar => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get gag => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get gab => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get gaa => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get brr => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get brg => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get brb => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get bra => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get bgr => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get bgg => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get bgb => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get bga => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get bbr => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get bbg => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get bbb => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get bba => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get bar => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get bag => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get bab => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get baa => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get arr => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get arg => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get arb => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get ara => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get agr => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get agg => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get agb => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get aga => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get abr => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get abg => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get abb => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get aba => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get aar => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get aag => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get aab => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get aaa => new Vector3(storage[3], storage[3], storage[3]);
-  Vector4 get rrrr =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get rrrg =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get rrrb =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
-  Vector4 get rrra =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
-  Vector4 get rrgr =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get rrgg =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get rrgb =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
-  Vector4 get rrga =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
-  Vector4 get rrbr =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
-  Vector4 get rrbg =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
-  Vector4 get rrbb =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
-  Vector4 get rrba =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
-  Vector4 get rrar =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
-  Vector4 get rrag =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
-  Vector4 get rrab =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
-  Vector4 get rraa =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
-  Vector4 get rgrr =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get rgrg =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get rgrb =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
-  Vector4 get rgra =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
-  Vector4 get rggr =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get rggg =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get rggb =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
-  Vector4 get rgga =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
-  Vector4 get rgbr =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
-  Vector4 get rgbg =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
-  Vector4 get rgbb =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
-  Vector4 get rgba =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
-  Vector4 get rgar =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
-  Vector4 get rgag =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
-  Vector4 get rgab =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
-  Vector4 get rgaa =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
-  Vector4 get rbrr =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
-  Vector4 get rbrg =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
-  Vector4 get rbrb =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
-  Vector4 get rbra =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
-  Vector4 get rbgr =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
-  Vector4 get rbgg =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
-  Vector4 get rbgb =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
-  Vector4 get rbga =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
-  Vector4 get rbbr =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
-  Vector4 get rbbg =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
-  Vector4 get rbbb =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
-  Vector4 get rbba =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
-  Vector4 get rbar =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
-  Vector4 get rbag =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
-  Vector4 get rbab =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
-  Vector4 get rbaa =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
-  Vector4 get rarr =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
-  Vector4 get rarg =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
-  Vector4 get rarb =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
-  Vector4 get rara =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
-  Vector4 get ragr =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
-  Vector4 get ragg =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
-  Vector4 get ragb =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
-  Vector4 get raga =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
-  Vector4 get rabr =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
-  Vector4 get rabg =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
-  Vector4 get rabb =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
-  Vector4 get raba =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
-  Vector4 get raar =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
-  Vector4 get raag =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
-  Vector4 get raab =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
-  Vector4 get raaa =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
-  Vector4 get grrr =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get grrg =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get grrb =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
-  Vector4 get grra =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
-  Vector4 get grgr =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get grgg =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get grgb =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
-  Vector4 get grga =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
-  Vector4 get grbr =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
-  Vector4 get grbg =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
-  Vector4 get grbb =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
-  Vector4 get grba =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
-  Vector4 get grar =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
-  Vector4 get grag =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
-  Vector4 get grab =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
-  Vector4 get graa =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
-  Vector4 get ggrr =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ggrg =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ggrb =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
-  Vector4 get ggra =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
-  Vector4 get gggr =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get gggg =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector4 get gggb =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
-  Vector4 get ggga =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
-  Vector4 get ggbr =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
-  Vector4 get ggbg =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
-  Vector4 get ggbb =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
-  Vector4 get ggba =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
-  Vector4 get ggar =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
-  Vector4 get ggag =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
-  Vector4 get ggab =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
-  Vector4 get ggaa =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
-  Vector4 get gbrr =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
-  Vector4 get gbrg =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
-  Vector4 get gbrb =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
-  Vector4 get gbra =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
-  Vector4 get gbgr =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
-  Vector4 get gbgg =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
-  Vector4 get gbgb =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
-  Vector4 get gbga =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
-  Vector4 get gbbr =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
-  Vector4 get gbbg =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
-  Vector4 get gbbb =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
-  Vector4 get gbba =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
-  Vector4 get gbar =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
-  Vector4 get gbag =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
-  Vector4 get gbab =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
-  Vector4 get gbaa =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
-  Vector4 get garr =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
-  Vector4 get garg =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
-  Vector4 get garb =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
-  Vector4 get gara =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
-  Vector4 get gagr =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
-  Vector4 get gagg =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
-  Vector4 get gagb =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
-  Vector4 get gaga =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
-  Vector4 get gabr =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
-  Vector4 get gabg =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
-  Vector4 get gabb =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
-  Vector4 get gaba =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
-  Vector4 get gaar =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
-  Vector4 get gaag =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
-  Vector4 get gaab =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
-  Vector4 get gaaa =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
-  Vector4 get brrr =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
-  Vector4 get brrg =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
-  Vector4 get brrb =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
-  Vector4 get brra =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
-  Vector4 get brgr =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
-  Vector4 get brgg =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
-  Vector4 get brgb =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
-  Vector4 get brga =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
-  Vector4 get brbr =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
-  Vector4 get brbg =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
-  Vector4 get brbb =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
-  Vector4 get brba =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
-  Vector4 get brar =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
-  Vector4 get brag =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
-  Vector4 get brab =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
-  Vector4 get braa =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
-  Vector4 get bgrr =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
-  Vector4 get bgrg =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
-  Vector4 get bgrb =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
-  Vector4 get bgra =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
-  Vector4 get bggr =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
-  Vector4 get bggg =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
-  Vector4 get bggb =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
-  Vector4 get bgga =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
-  Vector4 get bgbr =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
-  Vector4 get bgbg =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
-  Vector4 get bgbb =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
-  Vector4 get bgba =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
-  Vector4 get bgar =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
-  Vector4 get bgag =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
-  Vector4 get bgab =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
-  Vector4 get bgaa =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
-  Vector4 get bbrr =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
-  Vector4 get bbrg =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
-  Vector4 get bbrb =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
-  Vector4 get bbra =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
-  Vector4 get bbgr =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
-  Vector4 get bbgg =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
-  Vector4 get bbgb =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
-  Vector4 get bbga =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
-  Vector4 get bbbr =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
-  Vector4 get bbbg =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
-  Vector4 get bbbb =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
-  Vector4 get bbba =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
-  Vector4 get bbar =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
-  Vector4 get bbag =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
-  Vector4 get bbab =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
-  Vector4 get bbaa =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
-  Vector4 get barr =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
-  Vector4 get barg =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
-  Vector4 get barb =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
-  Vector4 get bara =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
-  Vector4 get bagr =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
-  Vector4 get bagg =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
-  Vector4 get bagb =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
-  Vector4 get baga =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
-  Vector4 get babr =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
-  Vector4 get babg =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
-  Vector4 get babb =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
-  Vector4 get baba =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
-  Vector4 get baar =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
-  Vector4 get baag =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
-  Vector4 get baab =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
-  Vector4 get baaa =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
-  Vector4 get arrr =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
-  Vector4 get arrg =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
-  Vector4 get arrb =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
-  Vector4 get arra =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
-  Vector4 get argr =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
-  Vector4 get argg =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
-  Vector4 get argb =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
-  Vector4 get arga =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
-  Vector4 get arbr =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
-  Vector4 get arbg =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
-  Vector4 get arbb =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
-  Vector4 get arba =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
-  Vector4 get arar =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
-  Vector4 get arag =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
-  Vector4 get arab =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
-  Vector4 get araa =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
-  Vector4 get agrr =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
-  Vector4 get agrg =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
-  Vector4 get agrb =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
-  Vector4 get agra =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
-  Vector4 get aggr =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
-  Vector4 get aggg =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
-  Vector4 get aggb =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
-  Vector4 get agga =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
-  Vector4 get agbr =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
-  Vector4 get agbg =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
-  Vector4 get agbb =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
-  Vector4 get agba =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
-  Vector4 get agar =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
-  Vector4 get agag =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
-  Vector4 get agab =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
-  Vector4 get agaa =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
-  Vector4 get abrr =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
-  Vector4 get abrg =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
-  Vector4 get abrb =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
-  Vector4 get abra =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
-  Vector4 get abgr =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
-  Vector4 get abgg =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
-  Vector4 get abgb =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
-  Vector4 get abga =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
-  Vector4 get abbr =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
-  Vector4 get abbg =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
-  Vector4 get abbb =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
-  Vector4 get abba =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
-  Vector4 get abar =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
-  Vector4 get abag =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
-  Vector4 get abab =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
-  Vector4 get abaa =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
-  Vector4 get aarr =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
-  Vector4 get aarg =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
-  Vector4 get aarb =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
-  Vector4 get aara =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
-  Vector4 get aagr =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
-  Vector4 get aagg =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
-  Vector4 get aagb =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
-  Vector4 get aaga =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
-  Vector4 get aabr =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
-  Vector4 get aabg =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
-  Vector4 get aabb =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
-  Vector4 get aaba =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
-  Vector4 get aaar =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
-  Vector4 get aaag =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
-  Vector4 get aaab =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
-  Vector4 get aaaa =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
-  Vector2 get ss => new Vector2(storage[0], storage[0]);
-  Vector2 get st => new Vector2(storage[0], storage[1]);
-  Vector2 get sp => new Vector2(storage[0], storage[2]);
-  Vector2 get sq => new Vector2(storage[0], storage[3]);
-  Vector2 get ts => new Vector2(storage[1], storage[0]);
-  Vector2 get tt => new Vector2(storage[1], storage[1]);
-  Vector2 get tp => new Vector2(storage[1], storage[2]);
-  Vector2 get tq => new Vector2(storage[1], storage[3]);
-  Vector2 get ps => new Vector2(storage[2], storage[0]);
-  Vector2 get pt => new Vector2(storage[2], storage[1]);
-  Vector2 get pp => new Vector2(storage[2], storage[2]);
-  Vector2 get pq => new Vector2(storage[2], storage[3]);
-  Vector2 get qs => new Vector2(storage[3], storage[0]);
-  Vector2 get qt => new Vector2(storage[3], storage[1]);
-  Vector2 get qp => new Vector2(storage[3], storage[2]);
-  Vector2 get qq => new Vector2(storage[3], storage[3]);
-  Vector3 get sss => new Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get sst => new Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get ssp => new Vector3(storage[0], storage[0], storage[2]);
-  Vector3 get ssq => new Vector3(storage[0], storage[0], storage[3]);
-  Vector3 get sts => new Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get stt => new Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get stp => new Vector3(storage[0], storage[1], storage[2]);
-  Vector3 get stq => new Vector3(storage[0], storage[1], storage[3]);
-  Vector3 get sps => new Vector3(storage[0], storage[2], storage[0]);
-  Vector3 get spt => new Vector3(storage[0], storage[2], storage[1]);
-  Vector3 get spp => new Vector3(storage[0], storage[2], storage[2]);
-  Vector3 get spq => new Vector3(storage[0], storage[2], storage[3]);
-  Vector3 get sqs => new Vector3(storage[0], storage[3], storage[0]);
-  Vector3 get sqt => new Vector3(storage[0], storage[3], storage[1]);
-  Vector3 get sqp => new Vector3(storage[0], storage[3], storage[2]);
-  Vector3 get sqq => new Vector3(storage[0], storage[3], storage[3]);
-  Vector3 get tss => new Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get tst => new Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get tsp => new Vector3(storage[1], storage[0], storage[2]);
-  Vector3 get tsq => new Vector3(storage[1], storage[0], storage[3]);
-  Vector3 get tts => new Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get ttt => new Vector3(storage[1], storage[1], storage[1]);
-  Vector3 get ttp => new Vector3(storage[1], storage[1], storage[2]);
-  Vector3 get ttq => new Vector3(storage[1], storage[1], storage[3]);
-  Vector3 get tps => new Vector3(storage[1], storage[2], storage[0]);
-  Vector3 get tpt => new Vector3(storage[1], storage[2], storage[1]);
-  Vector3 get tpp => new Vector3(storage[1], storage[2], storage[2]);
-  Vector3 get tpq => new Vector3(storage[1], storage[2], storage[3]);
-  Vector3 get tqs => new Vector3(storage[1], storage[3], storage[0]);
-  Vector3 get tqt => new Vector3(storage[1], storage[3], storage[1]);
-  Vector3 get tqp => new Vector3(storage[1], storage[3], storage[2]);
-  Vector3 get tqq => new Vector3(storage[1], storage[3], storage[3]);
-  Vector3 get pss => new Vector3(storage[2], storage[0], storage[0]);
-  Vector3 get pst => new Vector3(storage[2], storage[0], storage[1]);
-  Vector3 get psp => new Vector3(storage[2], storage[0], storage[2]);
-  Vector3 get psq => new Vector3(storage[2], storage[0], storage[3]);
-  Vector3 get pts => new Vector3(storage[2], storage[1], storage[0]);
-  Vector3 get ptt => new Vector3(storage[2], storage[1], storage[1]);
-  Vector3 get ptp => new Vector3(storage[2], storage[1], storage[2]);
-  Vector3 get ptq => new Vector3(storage[2], storage[1], storage[3]);
-  Vector3 get pps => new Vector3(storage[2], storage[2], storage[0]);
-  Vector3 get ppt => new Vector3(storage[2], storage[2], storage[1]);
-  Vector3 get ppp => new Vector3(storage[2], storage[2], storage[2]);
-  Vector3 get ppq => new Vector3(storage[2], storage[2], storage[3]);
-  Vector3 get pqs => new Vector3(storage[2], storage[3], storage[0]);
-  Vector3 get pqt => new Vector3(storage[2], storage[3], storage[1]);
-  Vector3 get pqp => new Vector3(storage[2], storage[3], storage[2]);
-  Vector3 get pqq => new Vector3(storage[2], storage[3], storage[3]);
-  Vector3 get qss => new Vector3(storage[3], storage[0], storage[0]);
-  Vector3 get qst => new Vector3(storage[3], storage[0], storage[1]);
-  Vector3 get qsp => new Vector3(storage[3], storage[0], storage[2]);
-  Vector3 get qsq => new Vector3(storage[3], storage[0], storage[3]);
-  Vector3 get qts => new Vector3(storage[3], storage[1], storage[0]);
-  Vector3 get qtt => new Vector3(storage[3], storage[1], storage[1]);
-  Vector3 get qtp => new Vector3(storage[3], storage[1], storage[2]);
-  Vector3 get qtq => new Vector3(storage[3], storage[1], storage[3]);
-  Vector3 get qps => new Vector3(storage[3], storage[2], storage[0]);
-  Vector3 get qpt => new Vector3(storage[3], storage[2], storage[1]);
-  Vector3 get qpp => new Vector3(storage[3], storage[2], storage[2]);
-  Vector3 get qpq => new Vector3(storage[3], storage[2], storage[3]);
-  Vector3 get qqs => new Vector3(storage[3], storage[3], storage[0]);
-  Vector3 get qqt => new Vector3(storage[3], storage[3], storage[1]);
-  Vector3 get qqp => new Vector3(storage[3], storage[3], storage[2]);
-  Vector3 get qqq => new Vector3(storage[3], storage[3], storage[3]);
-  Vector4 get ssss =>
-      new Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get ssst =>
-      new Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get sssp =>
-      new Vector4(storage[0], storage[0], storage[0], storage[2]);
-  Vector4 get sssq =>
-      new Vector4(storage[0], storage[0], storage[0], storage[3]);
-  Vector4 get ssts =>
-      new Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get sstt =>
-      new Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get sstp =>
-      new Vector4(storage[0], storage[0], storage[1], storage[2]);
-  Vector4 get sstq =>
-      new Vector4(storage[0], storage[0], storage[1], storage[3]);
-  Vector4 get ssps =>
-      new Vector4(storage[0], storage[0], storage[2], storage[0]);
-  Vector4 get sspt =>
-      new Vector4(storage[0], storage[0], storage[2], storage[1]);
-  Vector4 get sspp =>
-      new Vector4(storage[0], storage[0], storage[2], storage[2]);
-  Vector4 get sspq =>
-      new Vector4(storage[0], storage[0], storage[2], storage[3]);
-  Vector4 get ssqs =>
-      new Vector4(storage[0], storage[0], storage[3], storage[0]);
-  Vector4 get ssqt =>
-      new Vector4(storage[0], storage[0], storage[3], storage[1]);
-  Vector4 get ssqp =>
-      new Vector4(storage[0], storage[0], storage[3], storage[2]);
-  Vector4 get ssqq =>
-      new Vector4(storage[0], storage[0], storage[3], storage[3]);
-  Vector4 get stss =>
-      new Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get stst =>
-      new Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get stsp =>
-      new Vector4(storage[0], storage[1], storage[0], storage[2]);
-  Vector4 get stsq =>
-      new Vector4(storage[0], storage[1], storage[0], storage[3]);
-  Vector4 get stts =>
-      new Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get sttt =>
-      new Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get sttp =>
-      new Vector4(storage[0], storage[1], storage[1], storage[2]);
-  Vector4 get sttq =>
-      new Vector4(storage[0], storage[1], storage[1], storage[3]);
-  Vector4 get stps =>
-      new Vector4(storage[0], storage[1], storage[2], storage[0]);
-  Vector4 get stpt =>
-      new Vector4(storage[0], storage[1], storage[2], storage[1]);
-  Vector4 get stpp =>
-      new Vector4(storage[0], storage[1], storage[2], storage[2]);
-  Vector4 get stpq =>
-      new Vector4(storage[0], storage[1], storage[2], storage[3]);
-  Vector4 get stqs =>
-      new Vector4(storage[0], storage[1], storage[3], storage[0]);
-  Vector4 get stqt =>
-      new Vector4(storage[0], storage[1], storage[3], storage[1]);
-  Vector4 get stqp =>
-      new Vector4(storage[0], storage[1], storage[3], storage[2]);
-  Vector4 get stqq =>
-      new Vector4(storage[0], storage[1], storage[3], storage[3]);
-  Vector4 get spss =>
-      new Vector4(storage[0], storage[2], storage[0], storage[0]);
-  Vector4 get spst =>
-      new Vector4(storage[0], storage[2], storage[0], storage[1]);
-  Vector4 get spsp =>
-      new Vector4(storage[0], storage[2], storage[0], storage[2]);
-  Vector4 get spsq =>
-      new Vector4(storage[0], storage[2], storage[0], storage[3]);
-  Vector4 get spts =>
-      new Vector4(storage[0], storage[2], storage[1], storage[0]);
-  Vector4 get sptt =>
-      new Vector4(storage[0], storage[2], storage[1], storage[1]);
-  Vector4 get sptp =>
-      new Vector4(storage[0], storage[2], storage[1], storage[2]);
-  Vector4 get sptq =>
-      new Vector4(storage[0], storage[2], storage[1], storage[3]);
-  Vector4 get spps =>
-      new Vector4(storage[0], storage[2], storage[2], storage[0]);
-  Vector4 get sppt =>
-      new Vector4(storage[0], storage[2], storage[2], storage[1]);
-  Vector4 get sppp =>
-      new Vector4(storage[0], storage[2], storage[2], storage[2]);
-  Vector4 get sppq =>
-      new Vector4(storage[0], storage[2], storage[2], storage[3]);
-  Vector4 get spqs =>
-      new Vector4(storage[0], storage[2], storage[3], storage[0]);
-  Vector4 get spqt =>
-      new Vector4(storage[0], storage[2], storage[3], storage[1]);
-  Vector4 get spqp =>
-      new Vector4(storage[0], storage[2], storage[3], storage[2]);
-  Vector4 get spqq =>
-      new Vector4(storage[0], storage[2], storage[3], storage[3]);
-  Vector4 get sqss =>
-      new Vector4(storage[0], storage[3], storage[0], storage[0]);
-  Vector4 get sqst =>
-      new Vector4(storage[0], storage[3], storage[0], storage[1]);
-  Vector4 get sqsp =>
-      new Vector4(storage[0], storage[3], storage[0], storage[2]);
-  Vector4 get sqsq =>
-      new Vector4(storage[0], storage[3], storage[0], storage[3]);
-  Vector4 get sqts =>
-      new Vector4(storage[0], storage[3], storage[1], storage[0]);
-  Vector4 get sqtt =>
-      new Vector4(storage[0], storage[3], storage[1], storage[1]);
-  Vector4 get sqtp =>
-      new Vector4(storage[0], storage[3], storage[1], storage[2]);
-  Vector4 get sqtq =>
-      new Vector4(storage[0], storage[3], storage[1], storage[3]);
-  Vector4 get sqps =>
-      new Vector4(storage[0], storage[3], storage[2], storage[0]);
-  Vector4 get sqpt =>
-      new Vector4(storage[0], storage[3], storage[2], storage[1]);
-  Vector4 get sqpp =>
-      new Vector4(storage[0], storage[3], storage[2], storage[2]);
-  Vector4 get sqpq =>
-      new Vector4(storage[0], storage[3], storage[2], storage[3]);
-  Vector4 get sqqs =>
-      new Vector4(storage[0], storage[3], storage[3], storage[0]);
-  Vector4 get sqqt =>
-      new Vector4(storage[0], storage[3], storage[3], storage[1]);
-  Vector4 get sqqp =>
-      new Vector4(storage[0], storage[3], storage[3], storage[2]);
-  Vector4 get sqqq =>
-      new Vector4(storage[0], storage[3], storage[3], storage[3]);
-  Vector4 get tsss =>
-      new Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get tsst =>
-      new Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get tssp =>
-      new Vector4(storage[1], storage[0], storage[0], storage[2]);
-  Vector4 get tssq =>
-      new Vector4(storage[1], storage[0], storage[0], storage[3]);
-  Vector4 get tsts =>
-      new Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get tstt =>
-      new Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get tstp =>
-      new Vector4(storage[1], storage[0], storage[1], storage[2]);
-  Vector4 get tstq =>
-      new Vector4(storage[1], storage[0], storage[1], storage[3]);
-  Vector4 get tsps =>
-      new Vector4(storage[1], storage[0], storage[2], storage[0]);
-  Vector4 get tspt =>
-      new Vector4(storage[1], storage[0], storage[2], storage[1]);
-  Vector4 get tspp =>
-      new Vector4(storage[1], storage[0], storage[2], storage[2]);
-  Vector4 get tspq =>
-      new Vector4(storage[1], storage[0], storage[2], storage[3]);
-  Vector4 get tsqs =>
-      new Vector4(storage[1], storage[0], storage[3], storage[0]);
-  Vector4 get tsqt =>
-      new Vector4(storage[1], storage[0], storage[3], storage[1]);
-  Vector4 get tsqp =>
-      new Vector4(storage[1], storage[0], storage[3], storage[2]);
-  Vector4 get tsqq =>
-      new Vector4(storage[1], storage[0], storage[3], storage[3]);
-  Vector4 get ttss =>
-      new Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get ttst =>
-      new Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get ttsp =>
-      new Vector4(storage[1], storage[1], storage[0], storage[2]);
-  Vector4 get ttsq =>
-      new Vector4(storage[1], storage[1], storage[0], storage[3]);
-  Vector4 get ttts =>
-      new Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get tttt =>
-      new Vector4(storage[1], storage[1], storage[1], storage[1]);
-  Vector4 get tttp =>
-      new Vector4(storage[1], storage[1], storage[1], storage[2]);
-  Vector4 get tttq =>
-      new Vector4(storage[1], storage[1], storage[1], storage[3]);
-  Vector4 get ttps =>
-      new Vector4(storage[1], storage[1], storage[2], storage[0]);
-  Vector4 get ttpt =>
-      new Vector4(storage[1], storage[1], storage[2], storage[1]);
-  Vector4 get ttpp =>
-      new Vector4(storage[1], storage[1], storage[2], storage[2]);
-  Vector4 get ttpq =>
-      new Vector4(storage[1], storage[1], storage[2], storage[3]);
-  Vector4 get ttqs =>
-      new Vector4(storage[1], storage[1], storage[3], storage[0]);
-  Vector4 get ttqt =>
-      new Vector4(storage[1], storage[1], storage[3], storage[1]);
-  Vector4 get ttqp =>
-      new Vector4(storage[1], storage[1], storage[3], storage[2]);
-  Vector4 get ttqq =>
-      new Vector4(storage[1], storage[1], storage[3], storage[3]);
-  Vector4 get tpss =>
-      new Vector4(storage[1], storage[2], storage[0], storage[0]);
-  Vector4 get tpst =>
-      new Vector4(storage[1], storage[2], storage[0], storage[1]);
-  Vector4 get tpsp =>
-      new Vector4(storage[1], storage[2], storage[0], storage[2]);
-  Vector4 get tpsq =>
-      new Vector4(storage[1], storage[2], storage[0], storage[3]);
-  Vector4 get tpts =>
-      new Vector4(storage[1], storage[2], storage[1], storage[0]);
-  Vector4 get tptt =>
-      new Vector4(storage[1], storage[2], storage[1], storage[1]);
-  Vector4 get tptp =>
-      new Vector4(storage[1], storage[2], storage[1], storage[2]);
-  Vector4 get tptq =>
-      new Vector4(storage[1], storage[2], storage[1], storage[3]);
-  Vector4 get tpps =>
-      new Vector4(storage[1], storage[2], storage[2], storage[0]);
-  Vector4 get tppt =>
-      new Vector4(storage[1], storage[2], storage[2], storage[1]);
-  Vector4 get tppp =>
-      new Vector4(storage[1], storage[2], storage[2], storage[2]);
-  Vector4 get tppq =>
-      new Vector4(storage[1], storage[2], storage[2], storage[3]);
-  Vector4 get tpqs =>
-      new Vector4(storage[1], storage[2], storage[3], storage[0]);
-  Vector4 get tpqt =>
-      new Vector4(storage[1], storage[2], storage[3], storage[1]);
-  Vector4 get tpqp =>
-      new Vector4(storage[1], storage[2], storage[3], storage[2]);
-  Vector4 get tpqq =>
-      new Vector4(storage[1], storage[2], storage[3], storage[3]);
-  Vector4 get tqss =>
-      new Vector4(storage[1], storage[3], storage[0], storage[0]);
-  Vector4 get tqst =>
-      new Vector4(storage[1], storage[3], storage[0], storage[1]);
-  Vector4 get tqsp =>
-      new Vector4(storage[1], storage[3], storage[0], storage[2]);
-  Vector4 get tqsq =>
-      new Vector4(storage[1], storage[3], storage[0], storage[3]);
-  Vector4 get tqts =>
-      new Vector4(storage[1], storage[3], storage[1], storage[0]);
-  Vector4 get tqtt =>
-      new Vector4(storage[1], storage[3], storage[1], storage[1]);
-  Vector4 get tqtp =>
-      new Vector4(storage[1], storage[3], storage[1], storage[2]);
-  Vector4 get tqtq =>
-      new Vector4(storage[1], storage[3], storage[1], storage[3]);
-  Vector4 get tqps =>
-      new Vector4(storage[1], storage[3], storage[2], storage[0]);
-  Vector4 get tqpt =>
-      new Vector4(storage[1], storage[3], storage[2], storage[1]);
-  Vector4 get tqpp =>
-      new Vector4(storage[1], storage[3], storage[2], storage[2]);
-  Vector4 get tqpq =>
-      new Vector4(storage[1], storage[3], storage[2], storage[3]);
-  Vector4 get tqqs =>
-      new Vector4(storage[1], storage[3], storage[3], storage[0]);
-  Vector4 get tqqt =>
-      new Vector4(storage[1], storage[3], storage[3], storage[1]);
-  Vector4 get tqqp =>
-      new Vector4(storage[1], storage[3], storage[3], storage[2]);
-  Vector4 get tqqq =>
-      new Vector4(storage[1], storage[3], storage[3], storage[3]);
-  Vector4 get psss =>
-      new Vector4(storage[2], storage[0], storage[0], storage[0]);
-  Vector4 get psst =>
-      new Vector4(storage[2], storage[0], storage[0], storage[1]);
-  Vector4 get pssp =>
-      new Vector4(storage[2], storage[0], storage[0], storage[2]);
-  Vector4 get pssq =>
-      new Vector4(storage[2], storage[0], storage[0], storage[3]);
-  Vector4 get psts =>
-      new Vector4(storage[2], storage[0], storage[1], storage[0]);
-  Vector4 get pstt =>
-      new Vector4(storage[2], storage[0], storage[1], storage[1]);
-  Vector4 get pstp =>
-      new Vector4(storage[2], storage[0], storage[1], storage[2]);
-  Vector4 get pstq =>
-      new Vector4(storage[2], storage[0], storage[1], storage[3]);
-  Vector4 get psps =>
-      new Vector4(storage[2], storage[0], storage[2], storage[0]);
-  Vector4 get pspt =>
-      new Vector4(storage[2], storage[0], storage[2], storage[1]);
-  Vector4 get pspp =>
-      new Vector4(storage[2], storage[0], storage[2], storage[2]);
-  Vector4 get pspq =>
-      new Vector4(storage[2], storage[0], storage[2], storage[3]);
-  Vector4 get psqs =>
-      new Vector4(storage[2], storage[0], storage[3], storage[0]);
-  Vector4 get psqt =>
-      new Vector4(storage[2], storage[0], storage[3], storage[1]);
-  Vector4 get psqp =>
-      new Vector4(storage[2], storage[0], storage[3], storage[2]);
-  Vector4 get psqq =>
-      new Vector4(storage[2], storage[0], storage[3], storage[3]);
-  Vector4 get ptss =>
-      new Vector4(storage[2], storage[1], storage[0], storage[0]);
-  Vector4 get ptst =>
-      new Vector4(storage[2], storage[1], storage[0], storage[1]);
-  Vector4 get ptsp =>
-      new Vector4(storage[2], storage[1], storage[0], storage[2]);
-  Vector4 get ptsq =>
-      new Vector4(storage[2], storage[1], storage[0], storage[3]);
-  Vector4 get ptts =>
-      new Vector4(storage[2], storage[1], storage[1], storage[0]);
-  Vector4 get pttt =>
-      new Vector4(storage[2], storage[1], storage[1], storage[1]);
-  Vector4 get pttp =>
-      new Vector4(storage[2], storage[1], storage[1], storage[2]);
-  Vector4 get pttq =>
-      new Vector4(storage[2], storage[1], storage[1], storage[3]);
-  Vector4 get ptps =>
-      new Vector4(storage[2], storage[1], storage[2], storage[0]);
-  Vector4 get ptpt =>
-      new Vector4(storage[2], storage[1], storage[2], storage[1]);
-  Vector4 get ptpp =>
-      new Vector4(storage[2], storage[1], storage[2], storage[2]);
-  Vector4 get ptpq =>
-      new Vector4(storage[2], storage[1], storage[2], storage[3]);
-  Vector4 get ptqs =>
-      new Vector4(storage[2], storage[1], storage[3], storage[0]);
-  Vector4 get ptqt =>
-      new Vector4(storage[2], storage[1], storage[3], storage[1]);
-  Vector4 get ptqp =>
-      new Vector4(storage[2], storage[1], storage[3], storage[2]);
-  Vector4 get ptqq =>
-      new Vector4(storage[2], storage[1], storage[3], storage[3]);
-  Vector4 get ppss =>
-      new Vector4(storage[2], storage[2], storage[0], storage[0]);
-  Vector4 get ppst =>
-      new Vector4(storage[2], storage[2], storage[0], storage[1]);
-  Vector4 get ppsp =>
-      new Vector4(storage[2], storage[2], storage[0], storage[2]);
-  Vector4 get ppsq =>
-      new Vector4(storage[2], storage[2], storage[0], storage[3]);
-  Vector4 get ppts =>
-      new Vector4(storage[2], storage[2], storage[1], storage[0]);
-  Vector4 get pptt =>
-      new Vector4(storage[2], storage[2], storage[1], storage[1]);
-  Vector4 get pptp =>
-      new Vector4(storage[2], storage[2], storage[1], storage[2]);
-  Vector4 get pptq =>
-      new Vector4(storage[2], storage[2], storage[1], storage[3]);
-  Vector4 get ppps =>
-      new Vector4(storage[2], storage[2], storage[2], storage[0]);
-  Vector4 get pppt =>
-      new Vector4(storage[2], storage[2], storage[2], storage[1]);
-  Vector4 get pppp =>
-      new Vector4(storage[2], storage[2], storage[2], storage[2]);
-  Vector4 get pppq =>
-      new Vector4(storage[2], storage[2], storage[2], storage[3]);
-  Vector4 get ppqs =>
-      new Vector4(storage[2], storage[2], storage[3], storage[0]);
-  Vector4 get ppqt =>
-      new Vector4(storage[2], storage[2], storage[3], storage[1]);
-  Vector4 get ppqp =>
-      new Vector4(storage[2], storage[2], storage[3], storage[2]);
-  Vector4 get ppqq =>
-      new Vector4(storage[2], storage[2], storage[3], storage[3]);
-  Vector4 get pqss =>
-      new Vector4(storage[2], storage[3], storage[0], storage[0]);
-  Vector4 get pqst =>
-      new Vector4(storage[2], storage[3], storage[0], storage[1]);
-  Vector4 get pqsp =>
-      new Vector4(storage[2], storage[3], storage[0], storage[2]);
-  Vector4 get pqsq =>
-      new Vector4(storage[2], storage[3], storage[0], storage[3]);
-  Vector4 get pqts =>
-      new Vector4(storage[2], storage[3], storage[1], storage[0]);
-  Vector4 get pqtt =>
-      new Vector4(storage[2], storage[3], storage[1], storage[1]);
-  Vector4 get pqtp =>
-      new Vector4(storage[2], storage[3], storage[1], storage[2]);
-  Vector4 get pqtq =>
-      new Vector4(storage[2], storage[3], storage[1], storage[3]);
-  Vector4 get pqps =>
-      new Vector4(storage[2], storage[3], storage[2], storage[0]);
-  Vector4 get pqpt =>
-      new Vector4(storage[2], storage[3], storage[2], storage[1]);
-  Vector4 get pqpp =>
-      new Vector4(storage[2], storage[3], storage[2], storage[2]);
-  Vector4 get pqpq =>
-      new Vector4(storage[2], storage[3], storage[2], storage[3]);
-  Vector4 get pqqs =>
-      new Vector4(storage[2], storage[3], storage[3], storage[0]);
-  Vector4 get pqqt =>
-      new Vector4(storage[2], storage[3], storage[3], storage[1]);
-  Vector4 get pqqp =>
-      new Vector4(storage[2], storage[3], storage[3], storage[2]);
-  Vector4 get pqqq =>
-      new Vector4(storage[2], storage[3], storage[3], storage[3]);
-  Vector4 get qsss =>
-      new Vector4(storage[3], storage[0], storage[0], storage[0]);
-  Vector4 get qsst =>
-      new Vector4(storage[3], storage[0], storage[0], storage[1]);
-  Vector4 get qssp =>
-      new Vector4(storage[3], storage[0], storage[0], storage[2]);
-  Vector4 get qssq =>
-      new Vector4(storage[3], storage[0], storage[0], storage[3]);
-  Vector4 get qsts =>
-      new Vector4(storage[3], storage[0], storage[1], storage[0]);
-  Vector4 get qstt =>
-      new Vector4(storage[3], storage[0], storage[1], storage[1]);
-  Vector4 get qstp =>
-      new Vector4(storage[3], storage[0], storage[1], storage[2]);
-  Vector4 get qstq =>
-      new Vector4(storage[3], storage[0], storage[1], storage[3]);
-  Vector4 get qsps =>
-      new Vector4(storage[3], storage[0], storage[2], storage[0]);
-  Vector4 get qspt =>
-      new Vector4(storage[3], storage[0], storage[2], storage[1]);
-  Vector4 get qspp =>
-      new Vector4(storage[3], storage[0], storage[2], storage[2]);
-  Vector4 get qspq =>
-      new Vector4(storage[3], storage[0], storage[2], storage[3]);
-  Vector4 get qsqs =>
-      new Vector4(storage[3], storage[0], storage[3], storage[0]);
-  Vector4 get qsqt =>
-      new Vector4(storage[3], storage[0], storage[3], storage[1]);
-  Vector4 get qsqp =>
-      new Vector4(storage[3], storage[0], storage[3], storage[2]);
-  Vector4 get qsqq =>
-      new Vector4(storage[3], storage[0], storage[3], storage[3]);
-  Vector4 get qtss =>
-      new Vector4(storage[3], storage[1], storage[0], storage[0]);
-  Vector4 get qtst =>
-      new Vector4(storage[3], storage[1], storage[0], storage[1]);
-  Vector4 get qtsp =>
-      new Vector4(storage[3], storage[1], storage[0], storage[2]);
-  Vector4 get qtsq =>
-      new Vector4(storage[3], storage[1], storage[0], storage[3]);
-  Vector4 get qtts =>
-      new Vector4(storage[3], storage[1], storage[1], storage[0]);
-  Vector4 get qttt =>
-      new Vector4(storage[3], storage[1], storage[1], storage[1]);
-  Vector4 get qttp =>
-      new Vector4(storage[3], storage[1], storage[1], storage[2]);
-  Vector4 get qttq =>
-      new Vector4(storage[3], storage[1], storage[1], storage[3]);
-  Vector4 get qtps =>
-      new Vector4(storage[3], storage[1], storage[2], storage[0]);
-  Vector4 get qtpt =>
-      new Vector4(storage[3], storage[1], storage[2], storage[1]);
-  Vector4 get qtpp =>
-      new Vector4(storage[3], storage[1], storage[2], storage[2]);
-  Vector4 get qtpq =>
-      new Vector4(storage[3], storage[1], storage[2], storage[3]);
-  Vector4 get qtqs =>
-      new Vector4(storage[3], storage[1], storage[3], storage[0]);
-  Vector4 get qtqt =>
-      new Vector4(storage[3], storage[1], storage[3], storage[1]);
-  Vector4 get qtqp =>
-      new Vector4(storage[3], storage[1], storage[3], storage[2]);
-  Vector4 get qtqq =>
-      new Vector4(storage[3], storage[1], storage[3], storage[3]);
-  Vector4 get qpss =>
-      new Vector4(storage[3], storage[2], storage[0], storage[0]);
-  Vector4 get qpst =>
-      new Vector4(storage[3], storage[2], storage[0], storage[1]);
-  Vector4 get qpsp =>
-      new Vector4(storage[3], storage[2], storage[0], storage[2]);
-  Vector4 get qpsq =>
-      new Vector4(storage[3], storage[2], storage[0], storage[3]);
-  Vector4 get qpts =>
-      new Vector4(storage[3], storage[2], storage[1], storage[0]);
-  Vector4 get qptt =>
-      new Vector4(storage[3], storage[2], storage[1], storage[1]);
-  Vector4 get qptp =>
-      new Vector4(storage[3], storage[2], storage[1], storage[2]);
-  Vector4 get qptq =>
-      new Vector4(storage[3], storage[2], storage[1], storage[3]);
-  Vector4 get qpps =>
-      new Vector4(storage[3], storage[2], storage[2], storage[0]);
-  Vector4 get qppt =>
-      new Vector4(storage[3], storage[2], storage[2], storage[1]);
-  Vector4 get qppp =>
-      new Vector4(storage[3], storage[2], storage[2], storage[2]);
-  Vector4 get qppq =>
-      new Vector4(storage[3], storage[2], storage[2], storage[3]);
-  Vector4 get qpqs =>
-      new Vector4(storage[3], storage[2], storage[3], storage[0]);
-  Vector4 get qpqt =>
-      new Vector4(storage[3], storage[2], storage[3], storage[1]);
-  Vector4 get qpqp =>
-      new Vector4(storage[3], storage[2], storage[3], storage[2]);
-  Vector4 get qpqq =>
-      new Vector4(storage[3], storage[2], storage[3], storage[3]);
-  Vector4 get qqss =>
-      new Vector4(storage[3], storage[3], storage[0], storage[0]);
-  Vector4 get qqst =>
-      new Vector4(storage[3], storage[3], storage[0], storage[1]);
-  Vector4 get qqsp =>
-      new Vector4(storage[3], storage[3], storage[0], storage[2]);
-  Vector4 get qqsq =>
-      new Vector4(storage[3], storage[3], storage[0], storage[3]);
-  Vector4 get qqts =>
-      new Vector4(storage[3], storage[3], storage[1], storage[0]);
-  Vector4 get qqtt =>
-      new Vector4(storage[3], storage[3], storage[1], storage[1]);
-  Vector4 get qqtp =>
-      new Vector4(storage[3], storage[3], storage[1], storage[2]);
-  Vector4 get qqtq =>
-      new Vector4(storage[3], storage[3], storage[1], storage[3]);
-  Vector4 get qqps =>
-      new Vector4(storage[3], storage[3], storage[2], storage[0]);
-  Vector4 get qqpt =>
-      new Vector4(storage[3], storage[3], storage[2], storage[1]);
-  Vector4 get qqpp =>
-      new Vector4(storage[3], storage[3], storage[2], storage[2]);
-  Vector4 get qqpq =>
-      new Vector4(storage[3], storage[3], storage[2], storage[3]);
-  Vector4 get qqqs =>
-      new Vector4(storage[3], storage[3], storage[3], storage[0]);
-  Vector4 get qqqt =>
-      new Vector4(storage[3], storage[3], storage[3], storage[1]);
-  Vector4 get qqqp =>
-      new Vector4(storage[3], storage[3], storage[3], storage[2]);
-  Vector4 get qqqq =>
-      new Vector4(storage[3], storage[3], storage[3], storage[3]);
+      new Vector4(_storage[3], _storage[3], _storage[3], _storage[3]);
+  double get r => x;
+  double get g => y;
+  double get b => z;
+  double get a => w;
+  double get s => x;
+  double get t => y;
+  double get p => z;
+  double get q => w;
+  double get x => _storage[0];
+  double get y => _storage[1];
+  double get z => _storage[2];
+  double get w => _storage[3];
+  Vector2 get rr => xx;
+  Vector2 get rg => xy;
+  Vector2 get rb => xz;
+  Vector2 get ra => xw;
+  Vector2 get gr => yx;
+  Vector2 get gg => yy;
+  Vector2 get gb => yz;
+  Vector2 get ga => yw;
+  Vector2 get br => zx;
+  Vector2 get bg => zy;
+  Vector2 get bb => zz;
+  Vector2 get ba => zw;
+  Vector2 get ar => wx;
+  Vector2 get ag => wy;
+  Vector2 get ab => wz;
+  Vector2 get aa => ww;
+  Vector3 get rrr => xxx;
+  Vector3 get rrg => xxy;
+  Vector3 get rrb => xxz;
+  Vector3 get rra => xxw;
+  Vector3 get rgr => xyx;
+  Vector3 get rgg => xyy;
+  Vector3 get rgb => xyz;
+  Vector3 get rga => xyw;
+  Vector3 get rbr => xzx;
+  Vector3 get rbg => xzy;
+  Vector3 get rbb => xzz;
+  Vector3 get rba => xzw;
+  Vector3 get rar => xwx;
+  Vector3 get rag => xwy;
+  Vector3 get rab => xwz;
+  Vector3 get raa => xww;
+  Vector3 get grr => yxx;
+  Vector3 get grg => yxy;
+  Vector3 get grb => yxz;
+  Vector3 get gra => yxw;
+  Vector3 get ggr => yyx;
+  Vector3 get ggg => yyy;
+  Vector3 get ggb => yyz;
+  Vector3 get gga => yyw;
+  Vector3 get gbr => yzx;
+  Vector3 get gbg => yzy;
+  Vector3 get gbb => yzz;
+  Vector3 get gba => yzw;
+  Vector3 get gar => ywx;
+  Vector3 get gag => ywy;
+  Vector3 get gab => ywz;
+  Vector3 get gaa => yww;
+  Vector3 get brr => zxx;
+  Vector3 get brg => zxy;
+  Vector3 get brb => zxz;
+  Vector3 get bra => zxw;
+  Vector3 get bgr => zyx;
+  Vector3 get bgg => zyy;
+  Vector3 get bgb => zyz;
+  Vector3 get bga => zyw;
+  Vector3 get bbr => zzx;
+  Vector3 get bbg => zzy;
+  Vector3 get bbb => zzz;
+  Vector3 get bba => zzw;
+  Vector3 get bar => zwx;
+  Vector3 get bag => zwy;
+  Vector3 get bab => zwz;
+  Vector3 get baa => zww;
+  Vector3 get arr => wxx;
+  Vector3 get arg => wxy;
+  Vector3 get arb => wxz;
+  Vector3 get ara => wxw;
+  Vector3 get agr => wyx;
+  Vector3 get agg => wyy;
+  Vector3 get agb => wyz;
+  Vector3 get aga => wyw;
+  Vector3 get abr => wzx;
+  Vector3 get abg => wzy;
+  Vector3 get abb => wzz;
+  Vector3 get aba => wzw;
+  Vector3 get aar => wwx;
+  Vector3 get aag => wwy;
+  Vector3 get aab => wwz;
+  Vector3 get aaa => www;
+  Vector4 get rrrr => xxxx;
+  Vector4 get rrrg => xxxy;
+  Vector4 get rrrb => xxxz;
+  Vector4 get rrra => xxxw;
+  Vector4 get rrgr => xxyx;
+  Vector4 get rrgg => xxyy;
+  Vector4 get rrgb => xxyz;
+  Vector4 get rrga => xxyw;
+  Vector4 get rrbr => xxzx;
+  Vector4 get rrbg => xxzy;
+  Vector4 get rrbb => xxzz;
+  Vector4 get rrba => xxzw;
+  Vector4 get rrar => xxwx;
+  Vector4 get rrag => xxwy;
+  Vector4 get rrab => xxwz;
+  Vector4 get rraa => xxww;
+  Vector4 get rgrr => xyxx;
+  Vector4 get rgrg => xyxy;
+  Vector4 get rgrb => xyxz;
+  Vector4 get rgra => xyxw;
+  Vector4 get rggr => xyyx;
+  Vector4 get rggg => xyyy;
+  Vector4 get rggb => xyyz;
+  Vector4 get rgga => xyyw;
+  Vector4 get rgbr => xyzx;
+  Vector4 get rgbg => xyzy;
+  Vector4 get rgbb => xyzz;
+  Vector4 get rgba => xyzw;
+  Vector4 get rgar => xywx;
+  Vector4 get rgag => xywy;
+  Vector4 get rgab => xywz;
+  Vector4 get rgaa => xyww;
+  Vector4 get rbrr => xzxx;
+  Vector4 get rbrg => xzxy;
+  Vector4 get rbrb => xzxz;
+  Vector4 get rbra => xzxw;
+  Vector4 get rbgr => xzyx;
+  Vector4 get rbgg => xzyy;
+  Vector4 get rbgb => xzyz;
+  Vector4 get rbga => xzyw;
+  Vector4 get rbbr => xzzx;
+  Vector4 get rbbg => xzzy;
+  Vector4 get rbbb => xzzz;
+  Vector4 get rbba => xzzw;
+  Vector4 get rbar => xzwx;
+  Vector4 get rbag => xzwy;
+  Vector4 get rbab => xzwz;
+  Vector4 get rbaa => xzww;
+  Vector4 get rarr => xwxx;
+  Vector4 get rarg => xwxy;
+  Vector4 get rarb => xwxz;
+  Vector4 get rara => xwxw;
+  Vector4 get ragr => xwyx;
+  Vector4 get ragg => xwyy;
+  Vector4 get ragb => xwyz;
+  Vector4 get raga => xwyw;
+  Vector4 get rabr => xwzx;
+  Vector4 get rabg => xwzy;
+  Vector4 get rabb => xwzz;
+  Vector4 get raba => xwzw;
+  Vector4 get raar => xwwx;
+  Vector4 get raag => xwwy;
+  Vector4 get raab => xwwz;
+  Vector4 get raaa => xwww;
+  Vector4 get grrr => yxxx;
+  Vector4 get grrg => yxxy;
+  Vector4 get grrb => yxxz;
+  Vector4 get grra => yxxw;
+  Vector4 get grgr => yxyx;
+  Vector4 get grgg => yxyy;
+  Vector4 get grgb => yxyz;
+  Vector4 get grga => yxyw;
+  Vector4 get grbr => yxzx;
+  Vector4 get grbg => yxzy;
+  Vector4 get grbb => yxzz;
+  Vector4 get grba => yxzw;
+  Vector4 get grar => yxwx;
+  Vector4 get grag => yxwy;
+  Vector4 get grab => yxwz;
+  Vector4 get graa => yxww;
+  Vector4 get ggrr => yyxx;
+  Vector4 get ggrg => yyxy;
+  Vector4 get ggrb => yyxz;
+  Vector4 get ggra => yyxw;
+  Vector4 get gggr => yyyx;
+  Vector4 get gggg => yyyy;
+  Vector4 get gggb => yyyz;
+  Vector4 get ggga => yyyw;
+  Vector4 get ggbr => yyzx;
+  Vector4 get ggbg => yyzy;
+  Vector4 get ggbb => yyzz;
+  Vector4 get ggba => yyzw;
+  Vector4 get ggar => yywx;
+  Vector4 get ggag => yywy;
+  Vector4 get ggab => yywz;
+  Vector4 get ggaa => yyww;
+  Vector4 get gbrr => yzxx;
+  Vector4 get gbrg => yzxy;
+  Vector4 get gbrb => yzxz;
+  Vector4 get gbra => yzxw;
+  Vector4 get gbgr => yzyx;
+  Vector4 get gbgg => yzyy;
+  Vector4 get gbgb => yzyz;
+  Vector4 get gbga => yzyw;
+  Vector4 get gbbr => yzzx;
+  Vector4 get gbbg => yzzy;
+  Vector4 get gbbb => yzzz;
+  Vector4 get gbba => yzzw;
+  Vector4 get gbar => yzwx;
+  Vector4 get gbag => yzwy;
+  Vector4 get gbab => yzwz;
+  Vector4 get gbaa => yzww;
+  Vector4 get garr => ywxx;
+  Vector4 get garg => ywxy;
+  Vector4 get garb => ywxz;
+  Vector4 get gara => ywxw;
+  Vector4 get gagr => ywyx;
+  Vector4 get gagg => ywyy;
+  Vector4 get gagb => ywyz;
+  Vector4 get gaga => ywyw;
+  Vector4 get gabr => ywzx;
+  Vector4 get gabg => ywzy;
+  Vector4 get gabb => ywzz;
+  Vector4 get gaba => ywzw;
+  Vector4 get gaar => ywwx;
+  Vector4 get gaag => ywwy;
+  Vector4 get gaab => ywwz;
+  Vector4 get gaaa => ywww;
+  Vector4 get brrr => zxxx;
+  Vector4 get brrg => zxxy;
+  Vector4 get brrb => zxxz;
+  Vector4 get brra => zxxw;
+  Vector4 get brgr => zxyx;
+  Vector4 get brgg => zxyy;
+  Vector4 get brgb => zxyz;
+  Vector4 get brga => zxyw;
+  Vector4 get brbr => zxzx;
+  Vector4 get brbg => zxzy;
+  Vector4 get brbb => zxzz;
+  Vector4 get brba => zxzw;
+  Vector4 get brar => zxwx;
+  Vector4 get brag => zxwy;
+  Vector4 get brab => zxwz;
+  Vector4 get braa => zxww;
+  Vector4 get bgrr => zyxx;
+  Vector4 get bgrg => zyxy;
+  Vector4 get bgrb => zyxz;
+  Vector4 get bgra => zyxw;
+  Vector4 get bggr => zyyx;
+  Vector4 get bggg => zyyy;
+  Vector4 get bggb => zyyz;
+  Vector4 get bgga => zyyw;
+  Vector4 get bgbr => zyzx;
+  Vector4 get bgbg => zyzy;
+  Vector4 get bgbb => zyzz;
+  Vector4 get bgba => zyzw;
+  Vector4 get bgar => zywx;
+  Vector4 get bgag => zywy;
+  Vector4 get bgab => zywz;
+  Vector4 get bgaa => zyww;
+  Vector4 get bbrr => zzxx;
+  Vector4 get bbrg => zzxy;
+  Vector4 get bbrb => zzxz;
+  Vector4 get bbra => zzxw;
+  Vector4 get bbgr => zzyx;
+  Vector4 get bbgg => zzyy;
+  Vector4 get bbgb => zzyz;
+  Vector4 get bbga => zzyw;
+  Vector4 get bbbr => zzzx;
+  Vector4 get bbbg => zzzy;
+  Vector4 get bbbb => zzzz;
+  Vector4 get bbba => zzzw;
+  Vector4 get bbar => zzwx;
+  Vector4 get bbag => zzwy;
+  Vector4 get bbab => zzwz;
+  Vector4 get bbaa => zzww;
+  Vector4 get barr => zwxx;
+  Vector4 get barg => zwxy;
+  Vector4 get barb => zwxz;
+  Vector4 get bara => zwxw;
+  Vector4 get bagr => zwyx;
+  Vector4 get bagg => zwyy;
+  Vector4 get bagb => zwyz;
+  Vector4 get baga => zwyw;
+  Vector4 get babr => zwzx;
+  Vector4 get babg => zwzy;
+  Vector4 get babb => zwzz;
+  Vector4 get baba => zwzw;
+  Vector4 get baar => zwwx;
+  Vector4 get baag => zwwy;
+  Vector4 get baab => zwwz;
+  Vector4 get baaa => zwww;
+  Vector4 get arrr => wxxx;
+  Vector4 get arrg => wxxy;
+  Vector4 get arrb => wxxz;
+  Vector4 get arra => wxxw;
+  Vector4 get argr => wxyx;
+  Vector4 get argg => wxyy;
+  Vector4 get argb => wxyz;
+  Vector4 get arga => wxyw;
+  Vector4 get arbr => wxzx;
+  Vector4 get arbg => wxzy;
+  Vector4 get arbb => wxzz;
+  Vector4 get arba => wxzw;
+  Vector4 get arar => wxwx;
+  Vector4 get arag => wxwy;
+  Vector4 get arab => wxwz;
+  Vector4 get araa => wxww;
+  Vector4 get agrr => wyxx;
+  Vector4 get agrg => wyxy;
+  Vector4 get agrb => wyxz;
+  Vector4 get agra => wyxw;
+  Vector4 get aggr => wyyx;
+  Vector4 get aggg => wyyy;
+  Vector4 get aggb => wyyz;
+  Vector4 get agga => wyyw;
+  Vector4 get agbr => wyzx;
+  Vector4 get agbg => wyzy;
+  Vector4 get agbb => wyzz;
+  Vector4 get agba => wyzw;
+  Vector4 get agar => wywx;
+  Vector4 get agag => wywy;
+  Vector4 get agab => wywz;
+  Vector4 get agaa => wyww;
+  Vector4 get abrr => wzxx;
+  Vector4 get abrg => wzxy;
+  Vector4 get abrb => wzxz;
+  Vector4 get abra => wzxw;
+  Vector4 get abgr => wzyx;
+  Vector4 get abgg => wzyy;
+  Vector4 get abgb => wzyz;
+  Vector4 get abga => wzyw;
+  Vector4 get abbr => wzzx;
+  Vector4 get abbg => wzzy;
+  Vector4 get abbb => wzzz;
+  Vector4 get abba => wzzw;
+  Vector4 get abar => wzwx;
+  Vector4 get abag => wzwy;
+  Vector4 get abab => wzwz;
+  Vector4 get abaa => wzww;
+  Vector4 get aarr => wwxx;
+  Vector4 get aarg => wwxy;
+  Vector4 get aarb => wwxz;
+  Vector4 get aara => wwxw;
+  Vector4 get aagr => wwyx;
+  Vector4 get aagg => wwyy;
+  Vector4 get aagb => wwyz;
+  Vector4 get aaga => wwyw;
+  Vector4 get aabr => wwzx;
+  Vector4 get aabg => wwzy;
+  Vector4 get aabb => wwzz;
+  Vector4 get aaba => wwzw;
+  Vector4 get aaar => wwwx;
+  Vector4 get aaag => wwwy;
+  Vector4 get aaab => wwwz;
+  Vector4 get aaaa => wwww;
+  Vector2 get ss => xx;
+  Vector2 get st => xy;
+  Vector2 get sp => xz;
+  Vector2 get sq => xw;
+  Vector2 get ts => yx;
+  Vector2 get tt => yy;
+  Vector2 get tp => yz;
+  Vector2 get tq => yw;
+  Vector2 get ps => zx;
+  Vector2 get pt => zy;
+  Vector2 get pp => zz;
+  Vector2 get pq => zw;
+  Vector2 get qs => wx;
+  Vector2 get qt => wy;
+  Vector2 get qp => wz;
+  Vector2 get qq => ww;
+  Vector3 get sss => xxx;
+  Vector3 get sst => xxy;
+  Vector3 get ssp => xxz;
+  Vector3 get ssq => xxw;
+  Vector3 get sts => xyx;
+  Vector3 get stt => xyy;
+  Vector3 get stp => xyz;
+  Vector3 get stq => xyw;
+  Vector3 get sps => xzx;
+  Vector3 get spt => xzy;
+  Vector3 get spp => xzz;
+  Vector3 get spq => xzw;
+  Vector3 get sqs => xwx;
+  Vector3 get sqt => xwy;
+  Vector3 get sqp => xwz;
+  Vector3 get sqq => xww;
+  Vector3 get tss => yxx;
+  Vector3 get tst => yxy;
+  Vector3 get tsp => yxz;
+  Vector3 get tsq => yxw;
+  Vector3 get tts => yyx;
+  Vector3 get ttt => yyy;
+  Vector3 get ttp => yyz;
+  Vector3 get ttq => yyw;
+  Vector3 get tps => yzx;
+  Vector3 get tpt => yzy;
+  Vector3 get tpp => yzz;
+  Vector3 get tpq => yzw;
+  Vector3 get tqs => ywx;
+  Vector3 get tqt => ywy;
+  Vector3 get tqp => ywz;
+  Vector3 get tqq => yww;
+  Vector3 get pss => zxx;
+  Vector3 get pst => zxy;
+  Vector3 get psp => zxz;
+  Vector3 get psq => zxw;
+  Vector3 get pts => zyx;
+  Vector3 get ptt => zyy;
+  Vector3 get ptp => zyz;
+  Vector3 get ptq => zyw;
+  Vector3 get pps => zzx;
+  Vector3 get ppt => zzy;
+  Vector3 get ppp => zzz;
+  Vector3 get ppq => zzw;
+  Vector3 get pqs => zwx;
+  Vector3 get pqt => zwy;
+  Vector3 get pqp => zwz;
+  Vector3 get pqq => zww;
+  Vector3 get qss => wxx;
+  Vector3 get qst => wxy;
+  Vector3 get qsp => wxz;
+  Vector3 get qsq => wxw;
+  Vector3 get qts => wyx;
+  Vector3 get qtt => wyy;
+  Vector3 get qtp => wyz;
+  Vector3 get qtq => wyw;
+  Vector3 get qps => wzx;
+  Vector3 get qpt => wzy;
+  Vector3 get qpp => wzz;
+  Vector3 get qpq => wzw;
+  Vector3 get qqs => wwx;
+  Vector3 get qqt => wwy;
+  Vector3 get qqp => wwz;
+  Vector3 get qqq => www;
+  Vector4 get ssss => xxxx;
+  Vector4 get ssst => xxxy;
+  Vector4 get sssp => xxxz;
+  Vector4 get sssq => xxxw;
+  Vector4 get ssts => xxyx;
+  Vector4 get sstt => xxyy;
+  Vector4 get sstp => xxyz;
+  Vector4 get sstq => xxyw;
+  Vector4 get ssps => xxzx;
+  Vector4 get sspt => xxzy;
+  Vector4 get sspp => xxzz;
+  Vector4 get sspq => xxzw;
+  Vector4 get ssqs => xxwx;
+  Vector4 get ssqt => xxwy;
+  Vector4 get ssqp => xxwz;
+  Vector4 get ssqq => xxww;
+  Vector4 get stss => xyxx;
+  Vector4 get stst => xyxy;
+  Vector4 get stsp => xyxz;
+  Vector4 get stsq => xyxw;
+  Vector4 get stts => xyyx;
+  Vector4 get sttt => xyyy;
+  Vector4 get sttp => xyyz;
+  Vector4 get sttq => xyyw;
+  Vector4 get stps => xyzx;
+  Vector4 get stpt => xyzy;
+  Vector4 get stpp => xyzz;
+  Vector4 get stpq => xyzw;
+  Vector4 get stqs => xywx;
+  Vector4 get stqt => xywy;
+  Vector4 get stqp => xywz;
+  Vector4 get stqq => xyww;
+  Vector4 get spss => xzxx;
+  Vector4 get spst => xzxy;
+  Vector4 get spsp => xzxz;
+  Vector4 get spsq => xzxw;
+  Vector4 get spts => xzyx;
+  Vector4 get sptt => xzyy;
+  Vector4 get sptp => xzyz;
+  Vector4 get sptq => xzyw;
+  Vector4 get spps => xzzx;
+  Vector4 get sppt => xzzy;
+  Vector4 get sppp => xzzz;
+  Vector4 get sppq => xzzw;
+  Vector4 get spqs => xzwx;
+  Vector4 get spqt => xzwy;
+  Vector4 get spqp => xzwz;
+  Vector4 get spqq => xzww;
+  Vector4 get sqss => xwxx;
+  Vector4 get sqst => xwxy;
+  Vector4 get sqsp => xwxz;
+  Vector4 get sqsq => xwxw;
+  Vector4 get sqts => xwyx;
+  Vector4 get sqtt => xwyy;
+  Vector4 get sqtp => xwyz;
+  Vector4 get sqtq => xwyw;
+  Vector4 get sqps => xwzx;
+  Vector4 get sqpt => xwzy;
+  Vector4 get sqpp => xwzz;
+  Vector4 get sqpq => xwzw;
+  Vector4 get sqqs => xwwx;
+  Vector4 get sqqt => xwwy;
+  Vector4 get sqqp => xwwz;
+  Vector4 get sqqq => xwww;
+  Vector4 get tsss => yxxx;
+  Vector4 get tsst => yxxy;
+  Vector4 get tssp => yxxz;
+  Vector4 get tssq => yxxw;
+  Vector4 get tsts => yxyx;
+  Vector4 get tstt => yxyy;
+  Vector4 get tstp => yxyz;
+  Vector4 get tstq => yxyw;
+  Vector4 get tsps => yxzx;
+  Vector4 get tspt => yxzy;
+  Vector4 get tspp => yxzz;
+  Vector4 get tspq => yxzw;
+  Vector4 get tsqs => yxwx;
+  Vector4 get tsqt => yxwy;
+  Vector4 get tsqp => yxwz;
+  Vector4 get tsqq => yxww;
+  Vector4 get ttss => yyxx;
+  Vector4 get ttst => yyxy;
+  Vector4 get ttsp => yyxz;
+  Vector4 get ttsq => yyxw;
+  Vector4 get ttts => yyyx;
+  Vector4 get tttt => yyyy;
+  Vector4 get tttp => yyyz;
+  Vector4 get tttq => yyyw;
+  Vector4 get ttps => yyzx;
+  Vector4 get ttpt => yyzy;
+  Vector4 get ttpp => yyzz;
+  Vector4 get ttpq => yyzw;
+  Vector4 get ttqs => yywx;
+  Vector4 get ttqt => yywy;
+  Vector4 get ttqp => yywz;
+  Vector4 get ttqq => yyww;
+  Vector4 get tpss => yzxx;
+  Vector4 get tpst => yzxy;
+  Vector4 get tpsp => yzxz;
+  Vector4 get tpsq => yzxw;
+  Vector4 get tpts => yzyx;
+  Vector4 get tptt => yzyy;
+  Vector4 get tptp => yzyz;
+  Vector4 get tptq => yzyw;
+  Vector4 get tpps => yzzx;
+  Vector4 get tppt => yzzy;
+  Vector4 get tppp => yzzz;
+  Vector4 get tppq => yzzw;
+  Vector4 get tpqs => yzwx;
+  Vector4 get tpqt => yzwy;
+  Vector4 get tpqp => yzwz;
+  Vector4 get tpqq => yzww;
+  Vector4 get tqss => ywxx;
+  Vector4 get tqst => ywxy;
+  Vector4 get tqsp => ywxz;
+  Vector4 get tqsq => ywxw;
+  Vector4 get tqts => ywyx;
+  Vector4 get tqtt => ywyy;
+  Vector4 get tqtp => ywyz;
+  Vector4 get tqtq => ywyw;
+  Vector4 get tqps => ywzx;
+  Vector4 get tqpt => ywzy;
+  Vector4 get tqpp => ywzz;
+  Vector4 get tqpq => ywzw;
+  Vector4 get tqqs => ywwx;
+  Vector4 get tqqt => ywwy;
+  Vector4 get tqqp => ywwz;
+  Vector4 get tqqq => ywww;
+  Vector4 get psss => zxxx;
+  Vector4 get psst => zxxy;
+  Vector4 get pssp => zxxz;
+  Vector4 get pssq => zxxw;
+  Vector4 get psts => zxyx;
+  Vector4 get pstt => zxyy;
+  Vector4 get pstp => zxyz;
+  Vector4 get pstq => zxyw;
+  Vector4 get psps => zxzx;
+  Vector4 get pspt => zxzy;
+  Vector4 get pspp => zxzz;
+  Vector4 get pspq => zxzw;
+  Vector4 get psqs => zxwx;
+  Vector4 get psqt => zxwy;
+  Vector4 get psqp => zxwz;
+  Vector4 get psqq => zxww;
+  Vector4 get ptss => zyxx;
+  Vector4 get ptst => zyxy;
+  Vector4 get ptsp => zyxz;
+  Vector4 get ptsq => zyxw;
+  Vector4 get ptts => zyyx;
+  Vector4 get pttt => zyyy;
+  Vector4 get pttp => zyyz;
+  Vector4 get pttq => zyyw;
+  Vector4 get ptps => zyzx;
+  Vector4 get ptpt => zyzy;
+  Vector4 get ptpp => zyzz;
+  Vector4 get ptpq => zyzw;
+  Vector4 get ptqs => zywx;
+  Vector4 get ptqt => zywy;
+  Vector4 get ptqp => zywz;
+  Vector4 get ptqq => zyww;
+  Vector4 get ppss => zzxx;
+  Vector4 get ppst => zzxy;
+  Vector4 get ppsp => zzxz;
+  Vector4 get ppsq => zzxw;
+  Vector4 get ppts => zzyx;
+  Vector4 get pptt => zzyy;
+  Vector4 get pptp => zzyz;
+  Vector4 get pptq => zzyw;
+  Vector4 get ppps => zzzx;
+  Vector4 get pppt => zzzy;
+  Vector4 get pppp => zzzz;
+  Vector4 get pppq => zzzw;
+  Vector4 get ppqs => zzwx;
+  Vector4 get ppqt => zzwy;
+  Vector4 get ppqp => zzwz;
+  Vector4 get ppqq => zzww;
+  Vector4 get pqss => zwxx;
+  Vector4 get pqst => zwxy;
+  Vector4 get pqsp => zwxz;
+  Vector4 get pqsq => zwxw;
+  Vector4 get pqts => zwyx;
+  Vector4 get pqtt => zwyy;
+  Vector4 get pqtp => zwyz;
+  Vector4 get pqtq => zwyw;
+  Vector4 get pqps => zwzx;
+  Vector4 get pqpt => zwzy;
+  Vector4 get pqpp => zwzz;
+  Vector4 get pqpq => zwzw;
+  Vector4 get pqqs => zwwx;
+  Vector4 get pqqt => zwwy;
+  Vector4 get pqqp => zwwz;
+  Vector4 get pqqq => zwww;
+  Vector4 get qsss => wxxx;
+  Vector4 get qsst => wxxy;
+  Vector4 get qssp => wxxz;
+  Vector4 get qssq => wxxw;
+  Vector4 get qsts => wxyx;
+  Vector4 get qstt => wxyy;
+  Vector4 get qstp => wxyz;
+  Vector4 get qstq => wxyw;
+  Vector4 get qsps => wxzx;
+  Vector4 get qspt => wxzy;
+  Vector4 get qspp => wxzz;
+  Vector4 get qspq => wxzw;
+  Vector4 get qsqs => wxwx;
+  Vector4 get qsqt => wxwy;
+  Vector4 get qsqp => wxwz;
+  Vector4 get qsqq => wxww;
+  Vector4 get qtss => wyxx;
+  Vector4 get qtst => wyxy;
+  Vector4 get qtsp => wyxz;
+  Vector4 get qtsq => wyxw;
+  Vector4 get qtts => wyyx;
+  Vector4 get qttt => wyyy;
+  Vector4 get qttp => wyyz;
+  Vector4 get qttq => wyyw;
+  Vector4 get qtps => wyzx;
+  Vector4 get qtpt => wyzy;
+  Vector4 get qtpp => wyzz;
+  Vector4 get qtpq => wyzw;
+  Vector4 get qtqs => wywx;
+  Vector4 get qtqt => wywy;
+  Vector4 get qtqp => wywz;
+  Vector4 get qtqq => wyww;
+  Vector4 get qpss => wzxx;
+  Vector4 get qpst => wzxy;
+  Vector4 get qpsp => wzxz;
+  Vector4 get qpsq => wzxw;
+  Vector4 get qpts => wzyx;
+  Vector4 get qptt => wzyy;
+  Vector4 get qptp => wzyz;
+  Vector4 get qptq => wzyw;
+  Vector4 get qpps => wzzx;
+  Vector4 get qppt => wzzy;
+  Vector4 get qppp => wzzz;
+  Vector4 get qppq => wzzw;
+  Vector4 get qpqs => wzwx;
+  Vector4 get qpqt => wzwy;
+  Vector4 get qpqp => wzwz;
+  Vector4 get qpqq => wzww;
+  Vector4 get qqss => wwxx;
+  Vector4 get qqst => wwxy;
+  Vector4 get qqsp => wwxz;
+  Vector4 get qqsq => wwxw;
+  Vector4 get qqts => wwyx;
+  Vector4 get qqtt => wwyy;
+  Vector4 get qqtp => wwyz;
+  Vector4 get qqtq => wwyw;
+  Vector4 get qqps => wwzx;
+  Vector4 get qqpt => wwzy;
+  Vector4 get qqpp => wwzz;
+  Vector4 get qqpq => wwzw;
+  Vector4 get qqqs => wwwx;
+  Vector4 get qqqt => wwwy;
+  Vector4 get qqqp => wwwz;
+  Vector4 get qqqq => wwww;
 }

--- a/test/vector4_test.dart
+++ b/test/vector4_test.dart
@@ -4,11 +4,41 @@
 
 library vector_math.test.vector4_test;
 
+import 'dart:typed_data';
+
 import 'package:unittest/unittest.dart';
 
 import 'package:vector_math/vector_math.dart';
 
 import 'test_utils.dart';
+
+void testVector4InstacinfFromFloat32List() {
+  final float32List = new Float32List.fromList([1.0, 2.0, 3.0, 4.0]);
+  final input = new Vector4.fromFloat32List(float32List);
+
+  expect(input.x, equals(1.0));
+  expect(input.y, equals(2.0));
+  expect(input.z, equals(3.0));
+  expect(input.w, equals(4.0));
+}
+
+void testVector4InstacingFromByteBuffer() {
+  final float32List = new Float32List.fromList([1.0, 2.0, 3.0, 4.0, 5.0]);
+  final buffer = float32List.buffer;
+  final zeroOffset = new Vector4.fromBuffer(buffer, 0);
+  final offsetVector =
+      new Vector4.fromBuffer(buffer, Float32List.BYTES_PER_ELEMENT);
+
+  expect(zeroOffset.x, equals(1.0));
+  expect(zeroOffset.y, equals(2.0));
+  expect(zeroOffset.z, equals(3.0));
+  expect(zeroOffset.w, equals(4.0));
+
+  expect(offsetVector.x, equals(2.0));
+  expect(offsetVector.y, equals(3.0));
+  expect(offsetVector.z, equals(4.0));
+  expect(offsetVector.w, equals(5.0));
+}
 
 void testVector4Add() {
   final Vector4 a = new Vector4(5.0, 7.0, 3.0, 10.0);
@@ -126,18 +156,22 @@ void testVector4DistanceToSquared() {
 }
 
 void testVector4Clamp() {
-  final x = 2.0, y = 3.0, z = 4.0, w = 5.0;
+  final x = 2.0,
+      y = 3.0,
+      z = 4.0,
+      w = 5.0;
   final v0 = new Vector4(x, y, z, w);
   final v1 = new Vector4(-x, -y, -z, -w);
   final v2 = new Vector4(-2.0 * x, 2.0 * y, -2.0 * z, 2.0 * w)..clamp(v1, v0);
-  
+
   expect(v2.storage, orderedEquals([-x, y, -z, w]));
 }
 
 void testVector4ClampScalar() {
   final x = 2.0;
-  final v0 = new Vector4(-2.0 * x, 2.0 * x, -2.0 * x, 2.0 * x)..clampScalar(-x, x);
-  
+  final v0 = new Vector4(-2.0 * x, 2.0 * x, -2.0 * x, 2.0 * x)
+    ..clampScalar(-x, x);
+
   expect(v0.storage, orderedEquals([-x, x, -x, x]));
 }
 
@@ -145,7 +179,7 @@ void testVector4Floor() {
   final v0 = new Vector4(-0.1, 0.1, -0.1, 0.1)..floor();
   final v1 = new Vector4(-0.5, 0.5, -0.5, 0.5)..floor();
   final v2 = new Vector4(-0.9, 0.9, -0.5, 0.9)..floor();
-  
+
   expect(v0.storage, orderedEquals([-1.0, 0.0, -1.0, 0.0]));
   expect(v1.storage, orderedEquals([-1.0, 0.0, -1.0, 0.0]));
   expect(v2.storage, orderedEquals([-1.0, 0.0, -1.0, 0.0]));
@@ -155,7 +189,7 @@ void testVector4Ceil() {
   final v0 = new Vector4(-0.1, 0.1, -0.1, 0.1)..ceil();
   final v1 = new Vector4(-0.5, 0.5, -0.5, 0.5)..ceil();
   final v2 = new Vector4(-0.9, 0.9, -0.9, 0.9)..ceil();
-  
+
   expect(v0.storage, orderedEquals([0.0, 1.0, 0.0, 1.0]));
   expect(v1.storage, orderedEquals([0.0, 1.0, 0.0, 1.0]));
   expect(v2.storage, orderedEquals([0.0, 1.0, 0.0, 1.0]));
@@ -165,7 +199,7 @@ void testVector4Round() {
   final v0 = new Vector4(-0.1, 0.1, -0.1, 0.1)..round();
   final v1 = new Vector4(-0.5, 0.5, -0.5, 0.5)..round();
   final v2 = new Vector4(-0.9, 0.9, -0.9, 0.9)..round();
-  
+
   expect(v0.storage, orderedEquals([0.0, 0.0, 0.0, 0.0]));
   expect(v1.storage, orderedEquals([-1.0, 1.0, -1.0, 1.0]));
   expect(v2.storage, orderedEquals([-1.0, 1.0, -1.0, 1.0]));
@@ -178,7 +212,7 @@ void testVector4RoundToZero() {
   final v3 = new Vector4(-1.1, 1.1, -1.1, 1.1)..roundToZero();
   final v4 = new Vector4(-1.5, 1.5, -1.5, 1.5)..roundToZero();
   final v5 = new Vector4(-1.9, 1.9, -1.9, 1.9)..roundToZero();
-  
+
   expect(v0.storage, orderedEquals([0.0, 0.0, 0.0, 0.0]));
   expect(v1.storage, orderedEquals([0.0, 0.0, 0.0, 0.0]));
   expect(v2.storage, orderedEquals([0.0, 0.0, 0.0, 0.0]));
@@ -197,6 +231,8 @@ void main() {
     test('mix', testVector4Mix);
     test('distanceTo', testVector4DistanceTo);
     test('distanceToSquared', testVector4DistanceToSquared);
+    test('instancing from Float32List', testVector4InstacinfFromFloat32List);
+    test('instancing from ByteBuffer', testVector4InstacingFromByteBuffer);
     test('clamp', testVector4Clamp);
     test('clampScalar', testVector4ClampScalar);
     test('floor', testVector4Floor);


### PR DESCRIPTION
- Add additional constructors and their tests
- Always access private storage variable, inlining, remove duplicated code (as for Vector2)
- Make the color and tex-coord shuffle getters (rggb, tsss) delegating to the xyz variants. This is not designed as a performance improvement but should only make the code better to read and makes the file some (thousand) lines shorter.