### PR TITLE
Add Aabb3 - Triangle intersection test

### DIFF
--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -346,12 +346,18 @@ class Aabb3 {
   static final _u1 = new Vector3(0.0, 1.0, 0.0);
   static final _u2 = new Vector3(0.0, 0.0, 1.0);
 
-  /// Return if [this] intersects with [other]
+  /// Return if [this] intersects with [other].
+  /// [epsilon] allows the caller to specify a custum eplsilon value that should
+  /// be used for the test. If [result] is specified and an intersection is
+  /// found, result is modified to contain more details about the type of
+  /// intersection.
   bool intersectsWithTriangle(Triangle other,
       {double epsilon: 1e-3, IntersectionResult result}) {
     double p0, p1, p2, r, len;
     double a;
 
+    // This line isn't required if we are using center and half extents to
+    // define a aabb
     copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
 
     // Translate triangle as conceptually moving AABB to origin
@@ -609,7 +615,11 @@ class Aabb3 {
   static final _quadTriangle0 = new Triangle();
   static final _quadTriangle1 = new Triangle();
 
-  /// Return if [this] intersects with [other]
+  /// Return if [this] intersects with [other].
+  /// [epsilon] allows the caller to specify a custum eplsilon value that should
+  /// be used for the test. If [result] is specified and an intersection is
+  /// found, result is modified to contain more details about the type of
+  /// intersection.
   bool intersectsWithQuad(Quad other, {IntersectionResult result}) {
     other.copyTriangles(_quadTriangle0, _quadTriangle1);
 

--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -4,10 +4,6 @@
 
 part of vector_math;
 
-//TODO (fox32): Add setObb, fromObb
-//TODO (fox32): Add intersectsWithTriangle, intersectsWithPlane,
-// intersectsWithQuad and IntersectionResult
-
 /// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
 /// [max] position.
 class Aabb3 {
@@ -333,5 +329,291 @@ class Aabb3 {
         (_max.x >= other.x) &&
         (_max.y >= other.y) &&
         (_max.z >= other.z);
+  }
+
+  // Avoid allocating these instance on every call to intersectsWithTriangle
+  static final _aabbCenter = new Vector3.zero();
+  static final _aabbHalfExtents = new Vector3.zero();
+  static final _v0 = new Vector3.zero();
+  static final _v1 = new Vector3.zero();
+  static final _v2 = new Vector3.zero();
+  static final _f0 = new Vector3.zero();
+  static final _f1 = new Vector3.zero();
+  static final _f2 = new Vector3.zero();
+  static final _trianglePlane = new Plane();
+
+  static final _u0 = new Vector3(1.0, 0.0, 0.0);
+  static final _u1 = new Vector3(0.0, 1.0, 0.0);
+  static final _u2 = new Vector3(0.0, 0.0, 1.0);
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithTriangle(Triangle other,
+      {double epsilon: 1e-3, IntersectionResult result}) {
+    double p0, p1, p2, r, len;
+    double a;
+
+    copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
+
+    // Translate triangle as conceptually moving AABB to origin
+    _v0
+      ..setFrom(other.point0)
+      ..sub(_aabbCenter);
+    _v1
+      ..setFrom(other.point1)
+      ..sub(_aabbCenter);
+    _v2
+      ..setFrom(other.point2)
+      ..sub(_aabbCenter);
+
+    // Translate triangle as conceptually moving AABB to origin
+    _f0
+      ..setFrom(_v1)
+      ..sub(_v0);
+    _f1
+      ..setFrom(_v2)
+      ..sub(_v1);
+    _f2
+      ..setFrom(_v0)
+      ..sub(_v2);
+
+    // Test axes a00..a22 (category 3)
+    // Test axis a00
+    len = _f0.y * _f0.y + _f0.z * _f0.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f0.y - _v0.y * _f0.z;
+      p2 = _v2.z * _f0.y - _v2.y * _f0.z;
+      r = _aabbHalfExtents[1] * _f0.z.abs() + _aabbHalfExtents[2] * _f0.y.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a01
+    len = _f1.y * _f1.y + _f1.z * _f1.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f1.y - _v0.y * _f1.z;
+      p1 = _v1.z * _f1.y - _v1.y * _f1.z;
+      r = _aabbHalfExtents[1] * _f1.z.abs() + _aabbHalfExtents[2] * _f1.y.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a02
+    len = _f2.y * _f2.y + _f2.z * _f2.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f2.y - _v0.y * _f2.z;
+      p1 = _v1.z * _f2.y - _v1.y * _f2.z;
+      r = _aabbHalfExtents[1] * _f2.z.abs() + _aabbHalfExtents[2] * _f2.y.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test axis a10
+    len = _f0.x * _f0.x + _f0.z * _f0.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f0.z - _v0.z * _f0.x;
+      p2 = _v2.x * _f0.z - _v2.z * _f0.x;
+      r = _aabbHalfExtents[0] * _f0.z.abs() + _aabbHalfExtents[2] * _f0.x.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a11
+    len = _f1.x * _f1.x + _f1.z * _f1.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f1.z - _v0.z * _f1.x;
+      p1 = _v1.x * _f1.z - _v1.z * _f1.x;
+      r = _aabbHalfExtents[0] * _f1.z.abs() + _aabbHalfExtents[2] * _f1.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a12
+    len = _f2.x * _f2.x + _f2.z * _f2.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f2.z - _v0.z * _f2.x;
+      p1 = _v1.x * _f2.z - _v1.z * _f2.x;
+      r = _aabbHalfExtents[0] * _f2.z.abs() + _aabbHalfExtents[2] * _f2.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test axis a20
+    len = _f0.x * _f0.x + _f0.y * _f0.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f0.x - _v0.x * _f0.y;
+      p2 = _v2.y * _f0.x - _v2.x * _f0.y;
+      r = _aabbHalfExtents[0] * _f0.y.abs() + _aabbHalfExtents[1] * _f0.x.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a21
+    len = _f1.x * _f1.x + _f1.y * _f1.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f1.x - _v0.x * _f1.y;
+      p1 = _v1.y * _f1.x - _v1.x * _f1.y;
+      r = _aabbHalfExtents[0] * _f1.y.abs() + _aabbHalfExtents[1] * _f1.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a22
+    len = _f2.x * _f2.x + _f2.y * _f2.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f2.x - _v0.x * _f2.y;
+      p1 = _v1.y * _f2.x - _v1.x * _f2.y;
+      r = _aabbHalfExtents[0] * _f2.y.abs() + _aabbHalfExtents[1] * _f2.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test the three axes corresponding to the face normals of AABB b (category 1). // Exit if...
+    // ... [-e0, e0] and [min(v0.x,v1.x,v2.x), max(v0.x,v1.x,v2.x)] do not overlap
+    if (Math.max(_v0.x, Math.max(_v1.x, _v2.x)) < -_aabbHalfExtents[0] ||
+        Math.min(_v0.x, Math.min(_v1.x, _v2.x)) > _aabbHalfExtents[0]) {
+      return false;
+    }
+    a = Math.min(_v0.x, Math.min(_v1.x, _v2.x)) - _aabbHalfExtents[0];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u0);
+    }
+    // ... [-e1, e1] and [min(v0.y,v1.y,v2.y), max(v0.y,v1.y,v2.y)] do not overlap
+    if (Math.max(_v0.y, Math.max(_v1.y, _v2.y)) < -_aabbHalfExtents[1] ||
+        Math.min(_v0.y, Math.min(_v1.y, _v2.y)) > _aabbHalfExtents[1]) {
+      return false;
+    }
+    a = Math.min(_v0.y, Math.min(_v1.y, _v2.y)) - _aabbHalfExtents[1];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u1);
+    }
+    // ... [-e2, e2] and [min(v0.z,v1.z,v2.z), max(v0.z,v1.z,v2.z)] do not overlap
+    if (Math.max(_v0.z, Math.max(_v1.z, _v2.z)) < -_aabbHalfExtents[2] ||
+        Math.min(_v0.z, Math.min(_v1.z, _v2.z)) > _aabbHalfExtents[2]) {
+      return false;
+    }
+    a = Math.min(_v0.z, Math.min(_v1.z, _v2.z)) - _aabbHalfExtents[2];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u2);
+    }
+
+    // It seems like that wee need to move the edges before creating the
+    // plane
+    _v0.add(_aabbCenter);
+
+    // Test separating axis corresponding to triangle face normal (category 2)
+    _f0.crossInto(_f1, _trianglePlane.normal);
+    _trianglePlane.constant = _trianglePlane.normal.dot(_v0);
+    return intersectsWithPlane(_trianglePlane, result: result);
+  }
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithPlane(Plane other, {IntersectionResult result}) {
+    // This line is not necessary with a (center, extents) AABB representation
+    copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
+
+    // Compute the projection interval radius of b onto L(t) = b.c + t * p.n
+    double r = _aabbHalfExtents[0] * other.normal[0].abs() +
+        _aabbHalfExtents[1] * other.normal[1].abs() +
+        _aabbHalfExtents[2] * other.normal[2].abs();
+    // Compute distance of box center from plane
+    double s = other.normal.dot(_aabbCenter) - other.constant;
+    // Intersection occurs when distance s falls within [-r,+r] interval
+    if (s.abs() <= r) {
+      final a = s - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        result.axis.setFrom(other.normal);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // Avoid allocating these instance on every call to intersectsWithTriangle
+  static final _quadTriangle0 = new Triangle();
+  static final _quadTriangle1 = new Triangle();
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithQuad(Quad other, {IntersectionResult result}) {
+    other.copyTriangles(_quadTriangle0, _quadTriangle1);
+
+    return intersectsWithTriangle(_quadTriangle0, result: result) ||
+        intersectsWithTriangle(_quadTriangle1, result: result);
   }
 }

--- a/lib/src/vector_math/intersection_result.dart
+++ b/lib/src/vector_math/intersection_result.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+part of vector_math;
+
+/// Defines a result of an intersection test.
+class IntersectionResult {
+  double _depth;
+  /// The penetration depth of the intersection.
+  double get depth => _depth;
+  /// The [axis] of the intersection.
+  final Vector3 axis = new Vector3.zero();
+
+  IntersectionResult();
+}

--- a/lib/src/vector_math_64/aabb3.dart
+++ b/lib/src/vector_math_64/aabb3.dart
@@ -346,12 +346,18 @@ class Aabb3 {
   static final _u1 = new Vector3(0.0, 1.0, 0.0);
   static final _u2 = new Vector3(0.0, 0.0, 1.0);
 
-  /// Return if [this] intersects with [other]
+  /// Return if [this] intersects with [other].
+  /// [epsilon] allows the caller to specify a custum eplsilon value that should
+  /// be used for the test. If [result] is specified and an intersection is
+  /// found, result is modified to contain more details about the type of
+  /// intersection.
   bool intersectsWithTriangle(Triangle other,
       {double epsilon: 1e-3, IntersectionResult result}) {
     double p0, p1, p2, r, len;
     double a;
 
+    // This line isn't required if we are using center and half extents to
+    // define a aabb
     copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
 
     // Translate triangle as conceptually moving AABB to origin
@@ -609,7 +615,11 @@ class Aabb3 {
   static final _quadTriangle0 = new Triangle();
   static final _quadTriangle1 = new Triangle();
 
-  /// Return if [this] intersects with [other]
+  /// Return if [this] intersects with [other].
+  /// [epsilon] allows the caller to specify a custum eplsilon value that should
+  /// be used for the test. If [result] is specified and an intersection is
+  /// found, result is modified to contain more details about the type of
+  /// intersection.
   bool intersectsWithQuad(Quad other, {IntersectionResult result}) {
     other.copyTriangles(_quadTriangle0, _quadTriangle1);
 

--- a/lib/src/vector_math_64/aabb3.dart
+++ b/lib/src/vector_math_64/aabb3.dart
@@ -4,10 +4,6 @@
 
 part of vector_math_64;
 
-//TODO (fox32): Add setObb, fromObb
-//TODO (fox32): Add intersectsWithTriangle, intersectsWithPlane,
-// intersectsWithQuad and IntersectionResult
-
 /// Defines a 3-dimensional axis-aligned bounding box between a [min] and a
 /// [max] position.
 class Aabb3 {
@@ -333,5 +329,291 @@ class Aabb3 {
         (_max.x >= other.x) &&
         (_max.y >= other.y) &&
         (_max.z >= other.z);
+  }
+
+  // Avoid allocating these instance on every call to intersectsWithTriangle
+  static final _aabbCenter = new Vector3.zero();
+  static final _aabbHalfExtents = new Vector3.zero();
+  static final _v0 = new Vector3.zero();
+  static final _v1 = new Vector3.zero();
+  static final _v2 = new Vector3.zero();
+  static final _f0 = new Vector3.zero();
+  static final _f1 = new Vector3.zero();
+  static final _f2 = new Vector3.zero();
+  static final _trianglePlane = new Plane();
+
+  static final _u0 = new Vector3(1.0, 0.0, 0.0);
+  static final _u1 = new Vector3(0.0, 1.0, 0.0);
+  static final _u2 = new Vector3(0.0, 0.0, 1.0);
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithTriangle(Triangle other,
+      {double epsilon: 1e-3, IntersectionResult result}) {
+    double p0, p1, p2, r, len;
+    double a;
+
+    copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
+
+    // Translate triangle as conceptually moving AABB to origin
+    _v0
+      ..setFrom(other.point0)
+      ..sub(_aabbCenter);
+    _v1
+      ..setFrom(other.point1)
+      ..sub(_aabbCenter);
+    _v2
+      ..setFrom(other.point2)
+      ..sub(_aabbCenter);
+
+    // Translate triangle as conceptually moving AABB to origin
+    _f0
+      ..setFrom(_v1)
+      ..sub(_v0);
+    _f1
+      ..setFrom(_v2)
+      ..sub(_v1);
+    _f2
+      ..setFrom(_v0)
+      ..sub(_v2);
+
+    // Test axes a00..a22 (category 3)
+    // Test axis a00
+    len = _f0.y * _f0.y + _f0.z * _f0.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f0.y - _v0.y * _f0.z;
+      p2 = _v2.z * _f0.y - _v2.y * _f0.z;
+      r = _aabbHalfExtents[1] * _f0.z.abs() + _aabbHalfExtents[2] * _f0.y.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a01
+    len = _f1.y * _f1.y + _f1.z * _f1.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f1.y - _v0.y * _f1.z;
+      p1 = _v1.z * _f1.y - _v1.y * _f1.z;
+      r = _aabbHalfExtents[1] * _f1.z.abs() + _aabbHalfExtents[2] * _f1.y.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a02
+    len = _f2.y * _f2.y + _f2.z * _f2.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.z * _f2.y - _v0.y * _f2.z;
+      p1 = _v1.z * _f2.y - _v1.y * _f2.z;
+      r = _aabbHalfExtents[1] * _f2.z.abs() + _aabbHalfExtents[2] * _f2.y.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u0.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test axis a10
+    len = _f0.x * _f0.x + _f0.z * _f0.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f0.z - _v0.z * _f0.x;
+      p2 = _v2.x * _f0.z - _v2.z * _f0.x;
+      r = _aabbHalfExtents[0] * _f0.z.abs() + _aabbHalfExtents[2] * _f0.x.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a11
+    len = _f1.x * _f1.x + _f1.z * _f1.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f1.z - _v0.z * _f1.x;
+      p1 = _v1.x * _f1.z - _v1.z * _f1.x;
+      r = _aabbHalfExtents[0] * _f1.z.abs() + _aabbHalfExtents[2] * _f1.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a12
+    len = _f2.x * _f2.x + _f2.z * _f2.z;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.x * _f2.z - _v0.z * _f2.x;
+      p1 = _v1.x * _f2.z - _v1.z * _f2.x;
+      r = _aabbHalfExtents[0] * _f2.z.abs() + _aabbHalfExtents[2] * _f2.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u1.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test axis a20
+    len = _f0.x * _f0.x + _f0.y * _f0.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f0.x - _v0.x * _f0.y;
+      p2 = _v2.y * _f0.x - _v2.x * _f0.y;
+      r = _aabbHalfExtents[0] * _f0.y.abs() + _aabbHalfExtents[1] * _f0.x.abs();
+      if (Math.max(-Math.max(p0, p2), Math.min(p0, p2)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p2) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f0, result.axis);
+      }
+    }
+
+    // Test axis a21
+    len = _f1.x * _f1.x + _f1.y * _f1.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f1.x - _v0.x * _f1.y;
+      p1 = _v1.y * _f1.x - _v1.x * _f1.y;
+      r = _aabbHalfExtents[0] * _f1.y.abs() + _aabbHalfExtents[1] * _f1.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f1, result.axis);
+      }
+    }
+
+    // Test axis a22
+    len = _f2.x * _f2.x + _f2.y * _f2.y;
+    if (len > epsilon) {
+      // Ignore tests on degenerate axes.
+      p0 = _v0.y * _f2.x - _v0.x * _f2.y;
+      p1 = _v1.y * _f2.x - _v1.x * _f2.y;
+      r = _aabbHalfExtents[0] * _f2.y.abs() + _aabbHalfExtents[1] * _f2.x.abs();
+      if (Math.max(-Math.max(p0, p1), Math.min(p0, p1)) > r + epsilon) {
+        return false; // Axis is a separating axis
+      }
+
+      a = Math.min(p0, p1) - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        _u2.crossInto(_f2, result.axis);
+      }
+    }
+
+    // Test the three axes corresponding to the face normals of AABB b (category 1). // Exit if...
+    // ... [-e0, e0] and [min(v0.x,v1.x,v2.x), max(v0.x,v1.x,v2.x)] do not overlap
+    if (Math.max(_v0.x, Math.max(_v1.x, _v2.x)) < -_aabbHalfExtents[0] ||
+        Math.min(_v0.x, Math.min(_v1.x, _v2.x)) > _aabbHalfExtents[0]) {
+      return false;
+    }
+    a = Math.min(_v0.x, Math.min(_v1.x, _v2.x)) - _aabbHalfExtents[0];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u0);
+    }
+    // ... [-e1, e1] and [min(v0.y,v1.y,v2.y), max(v0.y,v1.y,v2.y)] do not overlap
+    if (Math.max(_v0.y, Math.max(_v1.y, _v2.y)) < -_aabbHalfExtents[1] ||
+        Math.min(_v0.y, Math.min(_v1.y, _v2.y)) > _aabbHalfExtents[1]) {
+      return false;
+    }
+    a = Math.min(_v0.y, Math.min(_v1.y, _v2.y)) - _aabbHalfExtents[1];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u1);
+    }
+    // ... [-e2, e2] and [min(v0.z,v1.z,v2.z), max(v0.z,v1.z,v2.z)] do not overlap
+    if (Math.max(_v0.z, Math.max(_v1.z, _v2.z)) < -_aabbHalfExtents[2] ||
+        Math.min(_v0.z, Math.min(_v1.z, _v2.z)) > _aabbHalfExtents[2]) {
+      return false;
+    }
+    a = Math.min(_v0.z, Math.min(_v1.z, _v2.z)) - _aabbHalfExtents[2];
+    if (result != null && (result._depth == null || result._depth < a)) {
+      result._depth = a;
+      result.axis.setFrom(_u2);
+    }
+
+    // It seems like that wee need to move the edges before creating the
+    // plane
+    _v0.add(_aabbCenter);
+
+    // Test separating axis corresponding to triangle face normal (category 2)
+    _f0.crossInto(_f1, _trianglePlane.normal);
+    _trianglePlane.constant = _trianglePlane.normal.dot(_v0);
+    return intersectsWithPlane(_trianglePlane, result: result);
+  }
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithPlane(Plane other, {IntersectionResult result}) {
+    // This line is not necessary with a (center, extents) AABB representation
+    copyCenterAndHalfExtents(_aabbCenter, _aabbHalfExtents);
+
+    // Compute the projection interval radius of b onto L(t) = b.c + t * p.n
+    double r = _aabbHalfExtents[0] * other.normal[0].abs() +
+        _aabbHalfExtents[1] * other.normal[1].abs() +
+        _aabbHalfExtents[2] * other.normal[2].abs();
+    // Compute distance of box center from plane
+    double s = other.normal.dot(_aabbCenter) - other.constant;
+    // Intersection occurs when distance s falls within [-r,+r] interval
+    if (s.abs() <= r) {
+      final a = s - r;
+      if (result != null && (result._depth == null || result._depth < a)) {
+        result._depth = a;
+        result.axis.setFrom(other.normal);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // Avoid allocating these instance on every call to intersectsWithTriangle
+  static final _quadTriangle0 = new Triangle();
+  static final _quadTriangle1 = new Triangle();
+
+  /// Return if [this] intersects with [other]
+  bool intersectsWithQuad(Quad other, {IntersectionResult result}) {
+    other.copyTriangles(_quadTriangle0, _quadTriangle1);
+
+    return intersectsWithTriangle(_quadTriangle0, result: result) ||
+        intersectsWithTriangle(_quadTriangle1, result: result);
   }
 }

--- a/lib/src/vector_math_64/intersection_result.dart
+++ b/lib/src/vector_math_64/intersection_result.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+part of vector_math_64;
+
+/// Defines a result of an intersection test.
+class IntersectionResult {
+  double _depth;
+  /// The penetration depth of the intersection.
+  double get depth => _depth;
+  /// The [axis] of the intersection.
+  final Vector3 axis = new Vector3.zero();
+
+  IntersectionResult();
+}

--- a/lib/vector_math.dart
+++ b/lib/vector_math.dart
@@ -29,6 +29,7 @@ part 'src/vector_math/colors.dart';
 part 'src/vector_math/constants.dart';
 part 'src/vector_math/error_helpers.dart';
 part 'src/vector_math/frustum.dart';
+part 'src/vector_math/intersection_result.dart';
 part 'src/vector_math/matrix2.dart';
 part 'src/vector_math/matrix3.dart';
 part 'src/vector_math/matrix4.dart';

--- a/lib/vector_math_64.dart
+++ b/lib/vector_math_64.dart
@@ -29,6 +29,7 @@ part 'src/vector_math_64/colors.dart';
 part 'src/vector_math_64/constants.dart';
 part 'src/vector_math_64/error_helpers.dart';
 part 'src/vector_math_64/frustum.dart';
+part 'src/vector_math_64/intersection_result.dart';
 part 'src/vector_math_64/matrix2.dart';
 part 'src/vector_math_64/matrix3.dart';
 part 'src/vector_math_64/matrix4.dart';

--- a/test/aabb3_test.dart
+++ b/test/aabb3_test.dart
@@ -211,6 +211,66 @@ void testAabb3IntersectionSphere() {
   expect(parent.intersectsWithSphere(outside), isFalse);
 }
 
+void testIntersectionTriangle() {
+  final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
+  final child = new Triangle.points(
+      $v3(2.0, 2.0, 2.0), $v3(3.0, 3.0, 3.0), $v3(4.0, 4.0, 4.0));
+  final edge = new Triangle.points(
+      $v3(1.0, 1.0, 1.0), $v3(3.0, 3.0, 3.0), $v3(4.0, 4.0, 4.0));
+  final cutting = new Triangle.points(
+      $v3(2.0, 2.0, 2.0), $v3(3.0, 3.0, 3.0), $v3(14.0, 14.0, 14.0));
+  final outside = new Triangle.points(
+      $v3(0.0, 0.0, 0.0), $v3(-3.0, -3.0, -3.0), $v3(-4.0, -4.0, -4.0));
+
+  expect(parent.intersectsWithTriangle(child), isTrue);
+  expect(parent.intersectsWithTriangle(edge), isTrue);
+  expect(parent.intersectsWithTriangle(cutting), isTrue);
+  expect(parent.intersectsWithTriangle(outside), isFalse);
+
+  // Special tests
+  final testAabb = new Aabb3.minMax(
+      $v3(20.458911895751953, -36.607460021972656, 2.549999952316284),
+      $v3(21.017810821533203, -36.192543029785156, 3.049999952316284));
+  final testTriangle = new Triangle.points(
+      $v3(20.5, -36.5, 3.5), $v3(21.5, -36.5, 2.5), $v3(20.5, -36.5, 2.5));
+  expect(testAabb.intersectsWithTriangle(testTriangle), isTrue);
+
+  final aabb = new Aabb3.minMax(
+      $v3(19.07674217224121, -39.46818161010742, 2.299999952316284),
+      $v3(19.40754508972168, -38.9503288269043, 2.799999952316284));
+  final triangle4 = new Triangle.points(
+      $v3(18.5, -39.5, 2.5), $v3(19.5, -39.5, 2.5), $v3(19.5, -38.5, 2.5));
+  final triangle4_1 = new Triangle.points(
+      $v3(19.5, -38.5, 2.5), $v3(19.5, -39.5, 2.5), $v3(18.5, -39.5, 2.5));
+  final triangle4_2 = new Triangle.points(
+      $v3(18.5, -39.5, 2.5), $v3(19.5, -38.5, 2.5), $v3(18.5, -38.5, 2.5));
+  final triangle4_3 = new Triangle.points(
+      $v3(18.5, -38.5, 2.5), $v3(19.5, -38.5, 2.5), $v3(18.5, -39.5, 2.5));
+
+  expect(aabb.intersectsWithTriangle(triangle4), isTrue);
+  expect(aabb.intersectsWithTriangle(triangle4_1), isTrue);
+  expect(aabb.intersectsWithTriangle(triangle4_2), isFalse);
+  expect(aabb.intersectsWithTriangle(triangle4_3), isFalse);
+}
+
+void testIntersectionPlane() {
+  final plane = new Plane.normalconstant($v3(1.0, 0.0, 0.0), 10.0);
+
+  final left = new Aabb3.minMax($v3(-5.0, -5.0, -5.0), $v3(5.0, 5.0, 5.0));
+  final right = new Aabb3.minMax($v3(15.0, 15.0, 15.0), $v3(30.0, 30.0, 30.0));
+  final intersect = new Aabb3.minMax($v3(5.0, 5.0, 5.0), $v3(15.0, 15.0, 15.0));
+
+  expect(left.intersectsWithPlane(plane), isFalse);
+  expect(right.intersectsWithPlane(plane), isFalse);
+
+  final result = new IntersectionResult();
+
+  expect(intersect.intersectsWithPlane(plane, result: result), isTrue);
+
+  relativeError(result.axis, $v3(1.0, 0.0, 0.0));
+  expect(result.depth, equals(-5.0));
+}
+
 void testAabb3IntersectionVector3() {
   final parent = new Aabb3.minMax($v3(1.0, 1.0, 1.0), $v3(8.0, 8.0, 8.0));
   final child = $v3(7.0, 7.0, 7.0);
@@ -278,6 +338,8 @@ void main() {
     test('Intersection Aabb3', testAabb3IntersectionAabb3);
     test('Intersection Vector3', testAabb3IntersectionVector3);
     test('Intersection Sphere', testAabb3IntersectionSphere);
+    test('Intersection Triangle', testIntersectionTriangle);
+    test('Intersection Plane', testIntersectionPlane);
     test('Hull', testAabb3Hull);
     test('Hull Point', testAabb3HullPoint);
   });


### PR DESCRIPTION
This PR implements a Aabb3 vs Triangle intersection. The implementation is based on the book Real Time Collision Detection. The test also provides more information about the type of intersection (intersection axis and penetration depth) if a IntersectionResult instance is provided when calling it.
To avoid allocations some internal used instances are implemented as preivate static variables and reused between invocations.
This PR also contains the unit test for the new feature.

This is a preperation for introducing a OBB type in the next PR (https://github.com/Fox32/vector_math/tree/feature/add-obb)