### PR TITLE
Fix typo: build-in to built-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ void main() {
 import 'package:vector_math/vector_math.dart';
 
 void main() {
-  // Access a build-in color, colors are stored in 4-dimensional vectors.
+  // Access a built-in color, colors are stored in 4-dimensional vectors.
   Vector4 red = Colors.red;
   Vector4 gray = Vector4.zero();
   // Convert the red color to a grayscaled color.


### PR DESCRIPTION
Corrects typo in README example 7 where 'build-in' should be 'built-in'.