### PR TITLE
Deprecate Matrix.copyInto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   Equivalent to the `leftTranslate` set of methods, that multiplies this matrix by a translation matrix from the left.
 - Added `Matrix4.leftMultiply` method.
 - Add `translateByVector2` method to `Matrix4`.
-- Deprecate `Matrix4.copyInto` - use `setFrom` instead.
 - Require `sdk: ^3.7.0`.
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.4.0-wip
 
+- Deprecate `MatrixX.copyInto` - use `setFrom` instead.
 - Remove the deprecated `SimplexNoise` class.
 
 ## 2.3.0
@@ -8,6 +9,7 @@
   Equivalent to the `leftTranslate` set of methods, that multiplies this matrix by a translation matrix from the left.
 - Added `Matrix4.leftMultiply` method.
 - Add `translateByVector2` method to `Matrix4`.
+- Deprecate `Matrix4.copyInto` - use `setFrom` instead.
 - Require `sdk: ^3.7.0`.
 
 ## 2.2.0

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -205,12 +205,9 @@ class Matrix2 {
   Matrix2 clone() => Matrix2.copy(this);
 
   /// Copy this into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix2 copyInto(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    argStorage[0] = _m2storage[0];
-    argStorage[1] = _m2storage[1];
-    argStorage[2] = _m2storage[2];
-    argStorage[3] = _m2storage[3];
+    arg.setFrom(this);
     return arg;
   }
 

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -338,17 +338,9 @@ class Matrix3 {
   Matrix3 clone() => Matrix3.copy(this);
 
   /// Copy this into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix3 copyInto(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    argStorage[0] = _m3storage[0];
-    argStorage[1] = _m3storage[1];
-    argStorage[2] = _m3storage[2];
-    argStorage[3] = _m3storage[3];
-    argStorage[4] = _m3storage[4];
-    argStorage[5] = _m3storage[5];
-    argStorage[6] = _m3storage[6];
-    argStorage[7] = _m3storage[7];
-    argStorage[8] = _m3storage[8];
+    arg.setFrom(this);
     return arg;
   }
 

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -649,24 +649,9 @@ class Matrix4 {
   Matrix4 clone() => Matrix4.copy(this);
 
   /// Copy into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix4 copyInto(Matrix4 arg) {
-    final argStorage = arg._m4storage;
-    argStorage[0] = _m4storage[0];
-    argStorage[1] = _m4storage[1];
-    argStorage[2] = _m4storage[2];
-    argStorage[3] = _m4storage[3];
-    argStorage[4] = _m4storage[4];
-    argStorage[5] = _m4storage[5];
-    argStorage[6] = _m4storage[6];
-    argStorage[7] = _m4storage[7];
-    argStorage[8] = _m4storage[8];
-    argStorage[9] = _m4storage[9];
-    argStorage[10] = _m4storage[10];
-    argStorage[11] = _m4storage[11];
-    argStorage[12] = _m4storage[12];
-    argStorage[13] = _m4storage[13];
-    argStorage[14] = _m4storage[14];
-    argStorage[15] = _m4storage[15];
+    arg.setFrom(this);
     return arg;
   }
 
@@ -1777,7 +1762,7 @@ class Matrix4 {
   /// Computes the result of `arg x this` and stores the result in-place in
   /// `this`.
   ///
-  /// This method does not alter the [Matrix4] in `arg`.
+  /// This method does not alter the [Matrix4] in [arg].
   void leftMultiply(Matrix4 arg) {
     final argStorage = arg._m4storage;
     final m00 = argStorage[0];

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -205,12 +205,9 @@ class Matrix2 {
   Matrix2 clone() => Matrix2.copy(this);
 
   /// Copy this into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix2 copyInto(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    argStorage[0] = _m2storage[0];
-    argStorage[1] = _m2storage[1];
-    argStorage[2] = _m2storage[2];
-    argStorage[3] = _m2storage[3];
+    arg.setFrom(this);
     return arg;
   }
 

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -338,17 +338,9 @@ class Matrix3 {
   Matrix3 clone() => Matrix3.copy(this);
 
   /// Copy this into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix3 copyInto(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    argStorage[0] = _m3storage[0];
-    argStorage[1] = _m3storage[1];
-    argStorage[2] = _m3storage[2];
-    argStorage[3] = _m3storage[3];
-    argStorage[4] = _m3storage[4];
-    argStorage[5] = _m3storage[5];
-    argStorage[6] = _m3storage[6];
-    argStorage[7] = _m3storage[7];
-    argStorage[8] = _m3storage[8];
+    arg.setFrom(this);
     return arg;
   }
 

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -649,24 +649,9 @@ class Matrix4 {
   Matrix4 clone() => Matrix4.copy(this);
 
   /// Copy into [arg].
+  @Deprecated('Use setFrom instead')
   Matrix4 copyInto(Matrix4 arg) {
-    final argStorage = arg._m4storage;
-    argStorage[0] = _m4storage[0];
-    argStorage[1] = _m4storage[1];
-    argStorage[2] = _m4storage[2];
-    argStorage[3] = _m4storage[3];
-    argStorage[4] = _m4storage[4];
-    argStorage[5] = _m4storage[5];
-    argStorage[6] = _m4storage[6];
-    argStorage[7] = _m4storage[7];
-    argStorage[8] = _m4storage[8];
-    argStorage[9] = _m4storage[9];
-    argStorage[10] = _m4storage[10];
-    argStorage[11] = _m4storage[11];
-    argStorage[12] = _m4storage[12];
-    argStorage[13] = _m4storage[13];
-    argStorage[14] = _m4storage[14];
-    argStorage[15] = _m4storage[15];
+    arg.setFrom(this);
     return arg;
   }
 


### PR DESCRIPTION
The code path is identical with setFrom
setFrom is implemented "better": copies from the last element first to
hopefully improve list bounds checking in the compiler
